### PR TITLE
Detect packaged Windows apps; improve login flow fallback

### DIFF
--- a/VardyParty/Components/Pages/Home.razor
+++ b/VardyParty/Components/Pages/Home.razor
@@ -351,7 +351,7 @@
 
         try
         {
-            if (MauiProgram.IsTv)
+            if (MauiProgram.IsTv || !MauiProgram.IsWindowsPackaged)
             {
                 var deviceLogin = await AuthLoginService.StartDeviceLoginAsync();
                 if (deviceLogin == null)

--- a/VardyParty/MauiProgram.cs
+++ b/VardyParty/MauiProgram.cs
@@ -25,6 +25,27 @@ public static class MauiProgram
     // Set by Android startup to indicate TV devices
     public static bool IsTv { get; set; } = false;
 
+    public static bool IsWindowsPackaged => _isWindowsPackaged;
+
+    private static readonly bool _isWindowsPackaged = DetectWindowsPackaged();
+
+    private static bool DetectWindowsPackaged()
+    {
+#if WINDOWS
+        try
+        {
+            _ = Windows.ApplicationModel.Package.Current.Id.FullName;
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+#else
+        return true;
+#endif
+    }
+
     // Set by Android startup to indicate whether a usable WebView implementation is present
     public static bool IsWebViewAvailable { get; set; } = false;
 

--- a/VardyParty/Services/Auth0AuthService.cs
+++ b/VardyParty/Services/Auth0AuthService.cs
@@ -40,6 +40,13 @@ public class Auth0AuthService(
         {
             if (HasValidToken) return new AuthLoginResult(true, _accessToken, null);
 
+            if (!MauiProgram.IsWindowsPackaged)
+            {
+                logger.LogWarning("[Auth0] Interactive login requires a packaged Windows app.");
+                return new AuthLoginResult(false, null,
+                    "Interactive login requires a packaged Windows app. Use device sign-in instead.");
+            }
+
             var client = BuildAuth0Client(_auth0Settings);
             logger.LogInformation("[Auth0] Starting login...");
 


### PR DESCRIPTION
Add MauiProgram.IsWindowsPackaged to detect packaged Windows apps using platform APIs. Update Home.razor and Auth0AuthService to use device sign-in for non-packaged Windows apps, blocking interactive login and providing user guidance. This ensures login flows are only attempted where supported and improves platform-specific feedback.