### PR TITLE
Add v2 stream resolution and LocalService LAN play for non-FB URLs

### DIFF
--- a/VardyParty.Core/Health/IStreamHealthReporter.cs
+++ b/VardyParty.Core/Health/IStreamHealthReporter.cs
@@ -4,9 +4,38 @@ namespace VardyParty.Services;
 
 public interface IStreamHealthReporter
 {
-    Task ReportPlaybackStartedAsync(string? streamUrl, string? refererUrl, PlaybackMetrics? metrics = null, CancellationToken cancellationToken = default);
-    Task ReportBufferingAsync(string? streamUrl, string? refererUrl, PlaybackMetrics? metrics = null, CancellationToken cancellationToken = default);
-    Task ReportPlaybackErrorAsync(string? streamUrl, string? refererUrl, string? error, CancellationToken cancellationToken = default);
-    Task ReportPlaybackMetricsAsync(string? streamUrl, string? refererUrl, PlaybackMetrics? metrics = null, CancellationToken cancellationToken = default);
-    Task ReportBadStreamAsync(string? streamUrl, string? refererUrl, string? reason = null, CancellationToken cancellationToken = default);
+    Task ReportPlaybackStartedAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        PlaybackMetrics? metrics = null,
+        CancellationToken cancellationToken = default);
+
+    Task ReportBufferingAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        PlaybackMetrics? metrics = null,
+        CancellationToken cancellationToken = default);
+
+    Task ReportPlaybackErrorAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        string? error = null,
+        CancellationToken cancellationToken = default);
+
+    Task ReportPlaybackMetricsAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        PlaybackMetrics? metrics = null,
+        CancellationToken cancellationToken = default);
+
+    Task ReportBadStreamAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        string? reason = null,
+        CancellationToken cancellationToken = default);
 }

--- a/VardyParty.Core/Health/StreamHealthChecker.cs
+++ b/VardyParty.Core/Health/StreamHealthChecker.cs
@@ -140,28 +140,22 @@ public class StreamHealthChecker(
         string content;
         try
         {
-            // Fetch manifest
-            // We can use a relatively short timeout for fetching headers/content
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(StreamHealthOptions.ManifestTimeoutSeconds));
 
-            var request = new HttpRequestMessage(HttpMethod.Get, url);
-            // Use a browser-like User-Agent to match playback and avoid hosts treating probe requests differently
-            request.Headers.TryAddWithoutValidation("User-Agent",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
-            if (!string.IsNullOrEmpty(refererUrl) && Uri.TryCreate(refererUrl, UriKind.Absolute, out var refUri))
-                request.Headers.Referrer = refUri;
-            logger.LogInformation("[StreamHealthChecker] Fetching manifest {Url} with referer {Referer}", url,
-                refererUrl);
-
-            var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
-            if (!response.IsSuccessStatusCode)
+            content = await FetchManifestContentAsync(url, refererUrl, cts.Token);
+            if (content is null && !string.IsNullOrEmpty(refererUrl))
             {
-                logger.LogWarning("Manifest fetch failed: {StatusCode} for {Url}", response.StatusCode, url);
-                return StreamHealthStatus.ManifestUnreachable;
+                logger.LogInformation(
+                    "[StreamHealthChecker] Manifest fetch with referer failed for {Url}; retrying without referer",
+                    url);
+                content = await FetchManifestContentAsync(url, refererUrl: null, cts.Token);
             }
 
-            content = await response.Content.ReadAsStringAsync(cts.Token);
+            if (content is null)
+            {
+                return StreamHealthStatus.ManifestUnreachable;
+            }
         }
         catch
         {
@@ -242,6 +236,27 @@ public class StreamHealthChecker(
         return relativeUrl;
     }
 
+    private async Task<string?> FetchManifestContentAsync(string url, string? refererUrl, CancellationToken ct)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.TryAddWithoutValidation("User-Agent",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
+        if (!string.IsNullOrEmpty(refererUrl) && Uri.TryCreate(refererUrl, UriKind.Absolute, out var refUri))
+            request.Headers.Referrer = refUri;
+        logger.LogInformation("[StreamHealthChecker] Fetching manifest {Url} with referer {Referer}", url,
+            refererUrl ?? "(none)");
+
+        var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogWarning("Manifest fetch failed: {StatusCode} for {Url}", response.StatusCode, url);
+            return null;
+        }
+
+        var content = await response.Content.ReadAsStringAsync(ct);
+        return string.IsNullOrWhiteSpace(content) ? null : content;
+    }
+
     private async Task<StreamHealthStatus> CheckSegmentAsync(string url, string refererUrl, CancellationToken ct)
     {
         try
@@ -249,35 +264,18 @@ public class StreamHealthChecker(
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(ct);
             cts.CancelAfter(TimeSpan.FromSeconds(StreamHealthOptions.SegmentTimeoutSeconds));
 
-            // Try HEAD first
-            var request = new HttpRequestMessage(HttpMethod.Head, url);
-            // Use a browser-like User-Agent to match playback
-            request.Headers.TryAddWithoutValidation("User-Agent",
-                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
-            if (!string.IsNullOrEmpty(refererUrl) && Uri.TryCreate(refererUrl, UriKind.Absolute, out var refUri))
-                request.Headers.Referrer = refUri;
-            logger.LogInformation("[StreamHealthChecker] Checking segment HEAD {Url} with referer {Referer}", url,
-                refererUrl);
-            var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cts.Token);
-
-            if (response.IsSuccessStatusCode) return StreamHealthStatus.Healthy;
-
-            // Some servers don't support HEAD or range properly, mostly HEAD.
-            // If MethodNotAllowed, try GET with range
-            if (response.StatusCode == System.Net.HttpStatusCode.MethodNotAllowed)
+            if (await ProbeSegmentAsync(HttpMethod.Head, url, refererUrl, cts.Token))
             {
-                var getReq = new HttpRequestMessage(HttpMethod.Get, url);
-                getReq.Headers.TryAddWithoutValidation("User-Agent",
-                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
-                if (!string.IsNullOrEmpty(refererUrl) && Uri.TryCreate(refererUrl, UriKind.Absolute, out _))
-                    getReq.Headers.Referrer = new Uri(refererUrl);
-                // Just get first byte to validate existence
-                getReq.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(0, 0);
-                var getResp = await httpClient.SendAsync(getReq, HttpCompletionOption.ResponseHeadersRead, cts.Token);
-                if (getResp.IsSuccessStatusCode) return StreamHealthStatus.Healthy;
+                return StreamHealthStatus.Healthy;
             }
 
-            logger.LogWarning("Segment check failed: {StatusCode} for {Url}", response.StatusCode, url);
+            // Tokenized CDNs often reject HEAD (403/401/405) while ranged GET succeeds.
+            if (await ProbeSegmentAsync(HttpMethod.Get, url, refererUrl, cts.Token, useRange: true))
+            {
+                return StreamHealthStatus.Healthy;
+            }
+
+            logger.LogWarning("Segment check failed for {Url}", url);
             return StreamHealthStatus.SegmentUnreachable;
         }
         catch (Exception ex)
@@ -285,5 +283,33 @@ public class StreamHealthChecker(
             logger.LogWarning(ex, "Segment exception for {Url}", url);
             return StreamHealthStatus.SegmentUnreachable;
         }
+    }
+
+    private async Task<bool> ProbeSegmentAsync(
+        HttpMethod method,
+        string url,
+        string refererUrl,
+        CancellationToken ct,
+        bool useRange = false)
+    {
+        var request = new HttpRequestMessage(method, url);
+        request.Headers.TryAddWithoutValidation("User-Agent",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
+        if (!string.IsNullOrEmpty(refererUrl) && Uri.TryCreate(refererUrl, UriKind.Absolute, out var refUri))
+            request.Headers.Referrer = refUri;
+        if (useRange)
+            request.Headers.Range = new System.Net.Http.Headers.RangeHeaderValue(0, 0);
+
+        logger.LogInformation("[StreamHealthChecker] Checking segment {Method} {Url} with referer {Referer}",
+            method.Method, url, refererUrl);
+
+        var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogDebug("Segment {Method} probe returned {StatusCode} for {Url}",
+                method.Method, response.StatusCode, url);
+        }
+
+        return response.IsSuccessStatusCode;
     }
 }

--- a/VardyParty.Core/Health/StreamHealthIdentity.cs
+++ b/VardyParty.Core/Health/StreamHealthIdentity.cs
@@ -1,0 +1,76 @@
+using VardyParty.Models;
+using StreamModel = VardyParty.Models.Stream;
+
+namespace VardyParty.Health;
+
+public static class StreamHealthIdentity
+{
+    private const string StreamKeySeparator = "::";
+
+    public static string? GetStreamName(StreamModel stream)
+    {
+        if (!stream.RequiresV2StreamSelection || stream.IsCountdown)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(stream.PlayerStream))
+        {
+            return stream.PlayerStream.Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(stream.Channel) ? null : stream.Channel.Trim();
+    }
+
+    public static (string StreamUrl, string? StreamName) FromStream(StreamModel stream)
+    {
+        return (stream.Url, GetStreamName(stream));
+    }
+
+    public static string NormalizeStreamUrl(string url) => NormalizeUrl(url);
+
+    public static string BuildStreamKey(string streamUrl, string? streamName = null)
+    {
+        var normalizedUrl = NormalizeUrl(streamUrl);
+        if (string.IsNullOrWhiteSpace(streamName))
+        {
+            return normalizedUrl;
+        }
+
+        return $"{normalizedUrl}{StreamKeySeparator}{streamName.Trim()}";
+    }
+
+    public static bool MatchesRecommendation(StreamModel stream, string recommendedUrl, string? recommendedStreamName)
+    {
+        if (!string.Equals(stream.Url, recommendedUrl, StringComparison.OrdinalIgnoreCase)
+            && !string.Equals(NormalizeUrl(stream.Url), NormalizeUrl(recommendedUrl), StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(recommendedStreamName))
+        {
+            return true;
+        }
+
+        var streamName = GetStreamName(stream);
+        return !string.IsNullOrWhiteSpace(streamName)
+               && string.Equals(streamName, recommendedStreamName.Trim(), StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static string NormalizeUrl(string url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return string.Empty;
+        }
+
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
+        {
+            var noQuery = url.Split('?', 2)[0];
+            return noQuery.Split('#', 2)[0].Trim();
+        }
+
+        return uri.GetLeftPart(UriPartial.Path);
+    }
+}

--- a/VardyParty.Core/Health/StreamHealthReporter.cs
+++ b/VardyParty.Core/Health/StreamHealthReporter.cs
@@ -9,41 +9,55 @@ public class StreamHealthReporter(
     ISessionIdProvider sessionIdProvider,
     SelectionState selectionState) : IStreamHealthReporter
 {
-    public Task ReportPlaybackStartedAsync(string? streamUrl, string? refererUrl, PlaybackMetrics? metrics = null,
-        CancellationToken cancellationToken = default)
-    {
-        return ReportAsync("working", streamUrl, refererUrl, metrics, null, true, cancellationToken);
-    }
+    public Task ReportPlaybackStartedAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        PlaybackMetrics? metrics = null,
+        CancellationToken cancellationToken = default) =>
+        ReportAsync("working", streamUrl, refererUrl, streamName, metrics, null, true, cancellationToken);
 
-    public Task ReportBufferingAsync(string? streamUrl, string? refererUrl, PlaybackMetrics? metrics = null,
-        CancellationToken cancellationToken = default)
-    {
-        return ReportAsync("buffering", streamUrl, refererUrl, metrics, null, false, cancellationToken);
-    }
+    public Task ReportBufferingAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        PlaybackMetrics? metrics = null,
+        CancellationToken cancellationToken = default) =>
+        ReportAsync("buffering", streamUrl, refererUrl, streamName, metrics, null, false, cancellationToken);
 
-    public Task ReportPlaybackErrorAsync(string? streamUrl, string? refererUrl, string? error,
-        CancellationToken cancellationToken = default)
-    {
-        return ReportAsync("failed", streamUrl, refererUrl, null, error, false, cancellationToken);
-    }
+    public Task ReportPlaybackErrorAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        string? error = null,
+        CancellationToken cancellationToken = default) =>
+        ReportAsync("failed", streamUrl, refererUrl, streamName, null, error, false, cancellationToken);
 
-    public Task ReportPlaybackMetricsAsync(string? streamUrl, string? refererUrl, PlaybackMetrics? metrics = null,
-        CancellationToken cancellationToken = default)
-    {
-        return ReportAsync("working", streamUrl, refererUrl, metrics, null, false, cancellationToken);
-    }
+    public Task ReportPlaybackMetricsAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        PlaybackMetrics? metrics = null,
+        CancellationToken cancellationToken = default) =>
+        ReportAsync("working", streamUrl, refererUrl, streamName, metrics, null, false, cancellationToken);
 
-    public Task ReportBadStreamAsync(string? streamUrl, string? refererUrl, string? reason = null,
+    public Task ReportBadStreamAsync(
+        string? streamUrl,
+        string? refererUrl,
+        string? streamName = null,
+        string? reason = null,
         CancellationToken cancellationToken = default)
     {
         var userReason = string.IsNullOrWhiteSpace(reason) ? "User reported bad stream" : reason;
-        return ReportAsync("user-report", streamUrl, refererUrl, null, userReason, false, cancellationToken);
+        return ReportAsync("user-report", streamUrl, refererUrl, streamName, null, userReason, false,
+            cancellationToken);
     }
 
     private async Task ReportAsync(
         string status,
         string? streamUrl,
         string? refererUrl,
+        string? streamName,
         PlaybackMetrics? metrics,
         string? error,
         bool includeMetadata,
@@ -58,12 +72,12 @@ public class StreamHealthReporter(
         var report = new StreamHealthReport
         {
             StreamUrl = resolvedStreamUrl,
+            StreamName = string.IsNullOrWhiteSpace(streamName) ? null : streamName.Trim(),
             Status = status,
             Quality = DetectQuality(metrics),
             Bitrate = metrics?.BitrateKbps,
             Buffering = status == "buffering" || metrics?.IsBuffering == true ? true : null,
             Error = error,
-            // Include video metadata ONLY on first playback started report
             Resolution = includeMetadata && metrics?.Resolution.HasValue == true
                 ? $"{metrics.Resolution.Value.Width}x{metrics.Resolution.Value.Height}"
                 : null,
@@ -93,7 +107,7 @@ public class StreamHealthReporter(
 
         if (metrics.IsBuffering) return "poor";
 
-        var (width, height) = metrics.Resolution.Value;
+        var (_, height) = metrics.Resolution.Value;
         if (metrics.BitrateKbps >= 2000 && height >= 720) return "excellent";
         if (metrics.BitrateKbps >= 1000 || height >= 480) return "good";
         return "poor";

--- a/VardyParty.Core/Models/EnrichedStream.cs
+++ b/VardyParty.Core/Models/EnrichedStream.cs
@@ -26,6 +26,11 @@ public class EnrichedStream
     public string? Referer { get; set; }
 
     /// <summary>
+    /// HTTP headers captured by Playwright when the m3u8 playlist was requested in-browser.
+    /// </summary>
+    public Dictionary<string, string>? RequestHeaders { get; set; }
+
+    /// <summary>
     /// Stream health and metadata extracted from the m3u8 manifest
     /// Populated after m3u8 is resolved and tested
     /// </summary>

--- a/VardyParty.Core/Models/M3U8Response.cs
+++ b/VardyParty.Core/Models/M3U8Response.cs
@@ -7,6 +7,9 @@ public class M3U8Response
     [JsonPropertyName("url")]
     public string Url { get; set; } = string.Empty;
     
+    [JsonPropertyName("requestHeaders")]
+    public Dictionary<string, string>? RequestHeaders { get; set; }
+    
     [JsonPropertyName("timings")]
     public M3U8Timings? Timings { get; set; }
 }

--- a/VardyParty.Core/Models/SelectionState.cs
+++ b/VardyParty.Core/Models/SelectionState.cs
@@ -9,4 +9,9 @@ public class SelectionState
     public string LastRoute { get; set; } = string.Empty;
     public string PreviousRoute { get; set; } = string.Empty;
     public Game? CurrentGame { get; set; }
+
+    /// <summary>
+    /// Stream currently playing or being health-reported (for v2 streamName identity).
+    /// </summary>
+    public Stream? CurrentStream { get; set; }
 }

--- a/VardyParty.Core/Models/StreamHealthModels.cs
+++ b/VardyParty.Core/Models/StreamHealthModels.cs
@@ -7,6 +7,12 @@ public class StreamHealthReport
     [JsonPropertyName("streamUrl")]
     public string StreamUrl { get; set; } = string.Empty;
 
+    /// <summary>
+    /// MadPlay / v2 player label when multiple streams share the same page URL.
+    /// </summary>
+    [JsonPropertyName("streamName")]
+    public string? StreamName { get; set; }
+
     [JsonPropertyName("status")]
     public string Status { get; set; } = string.Empty; // "working" | "failed" | "buffering" | "unknown"
 
@@ -58,6 +64,9 @@ public class RecommendationItem
     [JsonPropertyName("url")]
     public string Url { get; set; } = string.Empty;
 
+    [JsonPropertyName("streamName")]
+    public string? StreamName { get; set; }
+
     [JsonPropertyName("meta")]
     public StreamMeta? Meta { get; set; }
 }
@@ -93,6 +102,9 @@ public class StreamStats
 {
     [JsonPropertyName("streamUrl")]
     public string StreamUrl { get; set; } = string.Empty;
+
+    [JsonPropertyName("streamName")]
+    public string? StreamName { get; set; }
 
     [JsonPropertyName("successCount")]
     public int SuccessCount { get; set; }

--- a/VardyParty.Core/Models/StreamResponse.cs
+++ b/VardyParty.Core/Models/StreamResponse.cs
@@ -1,20 +1,100 @@
 namespace VardyParty.Models;
 
+
+
 public class StreamResponse
+
 {
+
     public string Href { get; set; } = string.Empty;
+
     public List<Stream> Streams { get; set; } = new();
+
 }
 
+
+
 public class Stream
+
 {
+
     public string Url { get; set; } = string.Empty;
+
     public string Channel { get; set; } = string.Empty;
+
     public string Reputation { get; set; } = string.Empty;
+
     public string Quality { get; set; } = string.Empty;
+
     public string Language { get; set; } = string.Empty;
+
     public int Ads { get; set; }
+
+
+
+    /// <summary>
+
+    /// How the local service should resolve this stream page (v2 = multi-stream picker).
+
+    /// </summary>
+
+    public string ResolutionStrategy { get; set; } = string.Empty;
+
+
+
+    /// <summary>
+
+    /// Player label to pass as <c>?stream=</c> when resolving via local service.
+
+    /// </summary>
+
+    public string PlayerStream { get; set; } = string.Empty;
+
+
+
+    /// <summary>
+
+    /// All player labels discovered on a multi-stream page (informational).
+
+    /// </summary>
+
+    public List<string> PlayerStreams { get; set; } = new();
+
+
+
+    /// <summary>
+
+    /// ready | countdown | unknown — from API v2 metadata when stream page is not live yet.
+
+    /// </summary>
+
+    public string StreamStatus { get; set; } = string.Empty;
+
+
+
     // Optional metadata found after m3u8 parsing
+
     public int? BitrateKbps { get; set; }
+
     public string? Resolution { get; set; }
+
+
+
+    public bool RequiresV2StreamSelection =>
+
+        string.Equals(ResolutionStrategy, "v2", StringComparison.OrdinalIgnoreCase);
+
+
+
+    public bool IsCountdown =>
+
+        string.Equals(StreamStatus, "countdown", StringComparison.OrdinalIgnoreCase);
+
+
+
+    public bool IsReadyForLocalResolution =>
+
+        !IsCountdown && !string.IsNullOrWhiteSpace(Url);
+
 }
+

--- a/VardyParty.Core/Models/StreamResponse.cs
+++ b/VardyParty.Core/Models/StreamResponse.cs
@@ -30,7 +30,11 @@ public class Stream
 
     public int Ads { get; set; }
 
-
+    /// <summary>
+    /// Catalog origin for this stream link: "fb" or "mp". Prefer <see cref="ResolveCatalogSource"/> —
+    /// never apply game-level sources to an individual stream.
+    /// </summary>
+    public string Source { get; set; } = string.Empty;
 
     /// <summary>
 
@@ -95,6 +99,50 @@ public class Stream
     public bool IsReadyForLocalResolution =>
 
         !IsCountdown && !string.IsNullOrWhiteSpace(Url);
+
+    /// <summary>
+    /// Per-stream catalog badge from URL/strategy evidence, not game-level sources.
+    /// </summary>
+    public string ResolveCatalogSource()
+    {
+        // URL host is authoritative — never trust sticky Source/strategy on FB URLs.
+        if (IsMpStreamUrl(Url))
+        {
+            return "mp";
+        }
+
+        if (!string.IsNullOrWhiteSpace(Url))
+        {
+            return "fb";
+        }
+
+        if (RequiresV2StreamSelection)
+        {
+            return "mp";
+        }
+
+        return string.Equals(Source, "mp", StringComparison.OrdinalIgnoreCase) ? "mp"
+            : string.Equals(Source, "fb", StringComparison.OrdinalIgnoreCase) ? "fb"
+            : string.Empty;
+    }
+
+    public string CatalogSourceBadgeLabel =>
+        ResolveCatalogSource() switch
+        {
+            "mp" => "V2",
+            "fb" => "FB",
+            _ => string.Empty
+        };
+
+    private static bool IsMpStreamUrl(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+        {
+            return false;
+        }
+
+        return url.Contains("mpoutqn", StringComparison.OrdinalIgnoreCase);
+    }
 
 }
 

--- a/VardyParty.Core/Orchestrators/StreamResolutionOrchestrator.cs
+++ b/VardyParty.Core/Orchestrators/StreamResolutionOrchestrator.cs
@@ -250,6 +250,9 @@ public class StreamResolutionOrchestrator(
         var reportingTask = StartPlaybackHealthReportingAsync(enrichedStream.Stream, playbackCts.Token);
         try
         {
+            // Warm the next candidate while this one plays so the first Next click is instant.
+            PrefetchUpcomingStreamUrl(game, cancellationToken);
+
             return await nativeVideoPlayer.PlayVideoAsync(
                 m3u8Url,
                 string.IsNullOrWhiteSpace(enrichedStream.Referer) ? enrichedStream.Stream.Url : enrichedStream.Referer,
@@ -354,6 +357,9 @@ public class StreamResolutionOrchestrator(
             return;
         }
 
+        // Prefer the queued m3u8 so Next is instant. Waiting on LocalService /play (~10–15s)
+        // before every switch makes the UI feel dead. Keep URLs fresh via background prefetch
+        // (see PrefetchUpcomingStreamUrl); resolve synchronously only when nothing is queued.
         if (string.IsNullOrEmpty(nextStream.ResolvedM3U8Url))
         {
             _status = "Switch requested - resolving stream URL...";
@@ -374,13 +380,15 @@ public class StreamResolutionOrchestrator(
             }
 
             nextStream.ResolvedM3U8Url = resolved;
+            logger.LogInformation(
+                "[StreamResolution] Resolved fresh M3U8 for next stream {Channel}",
+                nextStream.Stream.Channel);
         }
         else
         {
-            logger.LogInformation("[StreamResolution] Reusing queued M3U8 for next stream {Channel}",
+            logger.LogInformation(
+                "[StreamResolution] Reusing queued M3U8 for next stream {Channel}",
                 nextStream.Stream.Channel);
-            _status = "Switch requested - using queued stream";
-            PublishProgress();
         }
 
         if (streamSwitchingService.SwitchToNextStream())
@@ -388,7 +396,58 @@ public class StreamResolutionOrchestrator(
             logger.LogInformation("[StreamResolution] Switched to next stream");
             _status = "Switched to next stream";
             PublishProgress();
+            PrefetchUpcomingStreamUrl(game, cancellationToken);
         }
+    }
+
+    /// <summary>
+    /// Warm the next candidate's m3u8 in the background so the following Next click stays
+    /// instant without relying on a long-lived health-check URL.
+    /// </summary>
+    private void PrefetchUpcomingStreamUrl(Game game, CancellationToken cancellationToken)
+    {
+        var current = streamSwitchingService.GetCurrentStream();
+        var upcoming = streamSwitchingService.GetNextHealthyStream();
+        // With a single candidate, "next" wraps to current — don't re-resolve the live stream.
+        if (upcoming?.Stream == null || ReferenceEquals(upcoming, current)) return;
+
+        var channel = upcoming.Stream.Channel;
+        var path = $"/{game.ApiLeague}/{game.Home}/{game.Away}";
+        var stream = upcoming.Stream;
+
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var resolved = await apiService.ResolveM3U8ForPlaybackAsync(stream, path, cancellationToken);
+                if (string.IsNullOrEmpty(resolved))
+                {
+                    logger.LogDebug(
+                        "[StreamResolution] Prefetch skipped — no m3u8 for upcoming {Channel}",
+                        channel);
+                    return;
+                }
+
+                // Only write back if this is still the upcoming candidate (user may have switched).
+                var stillUpcoming = streamSwitchingService.GetNextHealthyStream();
+                if (stillUpcoming?.Stream == stream)
+                {
+                    stillUpcoming.ResolvedM3U8Url = resolved;
+                    logger.LogInformation(
+                        "[StreamResolution] Prefetched fresh M3U8 for upcoming stream {Channel}",
+                        channel);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex,
+                    "[StreamResolution] Prefetch failed for upcoming {Channel}",
+                    channel);
+            }
+        }, cancellationToken);
     }
 
     private async Task<bool> TryNextHealthyStreamAsync(Game game, CancellationToken cancellationToken)

--- a/VardyParty.Core/Orchestrators/StreamResolutionOrchestrator.cs
+++ b/VardyParty.Core/Orchestrators/StreamResolutionOrchestrator.cs
@@ -1,8 +1,10 @@
 using System.Reactive.Subjects;
 using Microsoft.Extensions.Logging;
+using VardyParty.Health;
 using VardyParty.Models;
 using VardyParty.Providers;
 using VardyParty.Services;
+using StreamModel = VardyParty.Models.Stream;
 
 namespace VardyParty.Orchestrators;
 
@@ -13,6 +15,7 @@ public class StreamResolutionOrchestrator(
     IStreamHealthService streamHealthService,
     IStreamHealthReporter streamHealthReporter,
     ISessionIdProvider sessionIdProvider,
+    SelectionState selectionState,
     IStreamSwitchingService streamSwitchingService,
     INativeVideoPlayerService nativeVideoPlayer,
     ILogger<StreamResolutionOrchestrator> logger) : IStreamResolutionOrchestrator
@@ -88,12 +91,13 @@ public class StreamResolutionOrchestrator(
 
             if (enrichedStream.Status == StreamResolutionStatus.Failed)
             {
-                _ = ReportHealthAsync(game, enrichedStream.Stream.Url, "failed", enrichedStream.ErrorMessage,
-                    cancellationToken);
+                _ = ReportHealthAsync(game, enrichedStream.Stream, "failed", enrichedStream.ErrorMessage,
+                    enrichedStream.Health, cancellationToken);
             }
             else if (enrichedStream.Status == StreamResolutionStatus.Healthy)
             {
-                _ = ReportHealthAsync(game, enrichedStream.Stream.Url, "unknown", null, cancellationToken);
+                _ = ReportHealthAsync(game, enrichedStream.Stream, "unknown", null, enrichedStream.Health,
+                    cancellationToken);
             }
 
             if (enrichedStream.Status != StreamResolutionStatus.Healthy)
@@ -165,23 +169,35 @@ public class StreamResolutionOrchestrator(
         return streamHealthReporter.ReportBadStreamAsync(
             currentStream.Stream.Url,
             currentStream.Stream.Url,
+            StreamHealthIdentity.GetStreamName(currentStream.Stream),
             reason,
             cancellationToken);
     }
 
-    private Task ReportHealthAsync(Game game, string? streamUrl, string status, string? error,
-        CancellationToken cancellationToken)
+    private Task ReportHealthAsync(
+        Game game,
+        StreamModel stream,
+        string status,
+        string? error,
+        StreamHealth? health = null,
+        CancellationToken cancellationToken = default)
     {
-        if (string.IsNullOrWhiteSpace(streamUrl))
+        if (string.IsNullOrWhiteSpace(stream.Url))
         {
             return Task.CompletedTask;
         }
 
         var report = new StreamHealthReport
         {
-            StreamUrl = streamUrl,
+            StreamUrl = stream.Url,
+            StreamName = StreamHealthIdentity.GetStreamName(stream),
             Status = status,
             Error = error,
+            Bitrate = health?.Bitrate,
+            Resolution = health?.Resolution,
+            Framerate = health?.FrameRate,
+            VideoCodec = health?.VideoCodec,
+            AudioCodec = health?.AudioCodec,
             Timestamp = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
             SessionId = sessionIdProvider.SessionId
         };
@@ -218,6 +234,8 @@ public class StreamResolutionOrchestrator(
         var title = $"{game.DisplayHome} vs {game.DisplayAway}";
         using var playbackCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
 
+        selectionState.CurrentStream = enrichedStream.Stream;
+
         // Reset buffering flag and subscribe to buffering events
         _hasBufferingOccurred = false;
         EventHandler<bool>? bufferingHandler = (sender, isBuffering) =>
@@ -229,17 +247,18 @@ public class StreamResolutionOrchestrator(
         };
         nativeVideoPlayer.BufferingStateChanged += bufferingHandler;
 
-        var reportingTask = StartPlaybackHealthReportingAsync(enrichedStream.Stream.Url, playbackCts.Token);
+        var reportingTask = StartPlaybackHealthReportingAsync(enrichedStream.Stream, playbackCts.Token);
         try
         {
             return await nativeVideoPlayer.PlayVideoAsync(
                 m3u8Url,
-                enrichedStream.Stream.Url,
+                string.IsNullOrWhiteSpace(enrichedStream.Referer) ? enrichedStream.Stream.Url : enrichedStream.Referer,
                 title,
                 () => HandleNextStreamRequestedAsync(game, cancellationToken),
                 game.DisplayLeague,
                 game.DisplayHome,
-                game.DisplayAway);
+                game.DisplayAway,
+                enrichedStream.RequestHeaders);
         }
         finally
         {
@@ -255,11 +274,12 @@ public class StreamResolutionOrchestrator(
         }
     }
 
-    private async Task StartPlaybackHealthReportingAsync(string? streamUrl, CancellationToken cancellationToken)
+    private async Task StartPlaybackHealthReportingAsync(StreamModel stream, CancellationToken cancellationToken)
     {
         try
         {
             var hasReportedMetadata = false;
+            var streamName = StreamHealthIdentity.GetStreamName(stream);
 
             // Wait for player to initialize and extract metadata
             // Windows MediaPlayer fires NaturalVideoSizeChanged after video decodes (~1-2s)
@@ -267,7 +287,8 @@ public class StreamResolutionOrchestrator(
 
             // Get real metrics from the player service after playback has started
             var initialMetrics = nativeVideoPlayer.GetCurrentMetrics();
-            _ = streamHealthReporter.ReportPlaybackStartedAsync(streamUrl, null, initialMetrics, cancellationToken);
+            _ = streamHealthReporter.ReportPlaybackStartedAsync(stream.Url, null, streamName, initialMetrics,
+                cancellationToken);
             hasReportedMetadata = initialMetrics?.Resolution.HasValue == true;
 
             while (!cancellationToken.IsCancellationRequested)
@@ -277,7 +298,8 @@ public class StreamResolutionOrchestrator(
                 var metrics = nativeVideoPlayer.GetCurrentMetrics();
 
                 // Report periodic metrics without duplicating metadata
-                _ = streamHealthReporter.ReportPlaybackMetricsAsync(streamUrl, null, metrics, cancellationToken);
+                _ = streamHealthReporter.ReportPlaybackMetricsAsync(stream.Url, null, streamName, metrics,
+                    cancellationToken);
             }
         }
         catch (OperationCanceledException)
@@ -389,7 +411,8 @@ public class StreamResolutionOrchestrator(
         PlaybackResult playbackResult,
         CancellationToken cancellationToken)
     {
-        _ = ReportHealthAsync(game, enrichedStream.Stream.Url, "failed", playbackResult.Message, cancellationToken);
+        _ = ReportHealthAsync(game, enrichedStream.Stream, "failed", playbackResult.Message, enrichedStream.Health,
+            cancellationToken);
 
         streamSwitchingService.RemoveCurrentStream();
         _healthyStreamCount = streamSwitchingService.GetHealthyStreams().Count;

--- a/VardyParty.Core/Orchestrators/StreamSelectionCoordinator.cs
+++ b/VardyParty.Core/Orchestrators/StreamSelectionCoordinator.cs
@@ -2,6 +2,7 @@ using System.Reactive.Subjects;
 using Microsoft.Extensions.Logging;
 using VardyParty.Health;
 using VardyParty.Models;
+using VardyParty.Resolvers;
 using VardyParty.Services;
 using StreamModel = VardyParty.Models.Stream;
 
@@ -19,7 +20,7 @@ public class StreamSelectionCoordinator(
     private readonly Queue<int> _pendingIndexes = new();
     private readonly HashSet<int> _testedIndexes = new();
     private readonly HashSet<int> _workingIndexes = new();
-    private readonly Dictionary<string, int> _streamIndexByUrl = new(StringComparer.OrdinalIgnoreCase);
+    private readonly Dictionary<string, int> _streamIndexByKey = new(StringComparer.OrdinalIgnoreCase);
 
     private bool _paused;
     private int _totalStreams;
@@ -37,8 +38,10 @@ public class StreamSelectionCoordinator(
             return;
         }
 
-        _totalStreams = streamsResponse.Streams.Count;
-        BuildCandidates(streamsResponse.Streams);
+        var expandedStreams = StreamCatalogSourceOrderer.OrderFbBeforeMp(
+            V2StreamExpander.Expand(streamsResponse.Streams));
+        _totalStreams = expandedStreams.Count;
+        BuildCandidates(expandedStreams);
 
         List<int> testOrder = new();
         try
@@ -158,10 +161,10 @@ public class StreamSelectionCoordinator(
         index = -1;
         if (string.IsNullOrWhiteSpace(streamUrlOrReferer)) return false;
 
-        var normalized = NormalizeStreamUrl(streamUrlOrReferer);
-        if (_streamIndexByUrl.TryGetValue(normalized, out index)) return true;
+        var normalized = StreamHealthIdentity.NormalizeStreamUrl(streamUrlOrReferer);
+        if (_streamIndexByKey.TryGetValue(normalized, out index)) return true;
 
-        return _streamIndexByUrl.TryGetValue(streamUrlOrReferer, out index);
+        return _streamIndexByKey.TryGetValue(streamUrlOrReferer, out index);
     }
 
     public void Reset()
@@ -172,7 +175,7 @@ public class StreamSelectionCoordinator(
         _pendingIndexes.Clear();
         _testedIndexes.Clear();
         _workingIndexes.Clear();
-        _streamIndexByUrl.Clear();
+        _streamIndexByKey.Clear();
         PublishProgress();
     }
 
@@ -181,7 +184,8 @@ public class StreamSelectionCoordinator(
         for (var i = 0; i < streams.Count; i++)
         {
             var stream = streams[i];
-            var normalized = NormalizeStreamUrl(stream.Url);
+            var normalized = StreamHealthIdentity.NormalizeStreamUrl(stream.Url);
+            var streamKey = StreamHealthIdentity.BuildStreamKey(stream.Url, StreamHealthIdentity.GetStreamName(stream));
             var candidate = new StreamSelectionCandidate
             {
                 Index = i,
@@ -190,14 +194,19 @@ public class StreamSelectionCoordinator(
             };
 
             _candidates.Add(candidate);
+            if (!string.IsNullOrWhiteSpace(streamKey))
+            {
+                _streamIndexByKey[streamKey] = i;
+            }
+
             if (!string.IsNullOrWhiteSpace(normalized))
             {
-                _streamIndexByUrl[normalized] = i;
+                _streamIndexByKey[normalized] = i;
             }
 
             if (!string.IsNullOrWhiteSpace(stream.Url))
             {
-                _streamIndexByUrl[stream.Url] = i;
+                _streamIndexByKey[stream.Url] = i;
             }
         }
     }
@@ -216,19 +225,7 @@ public class StreamSelectionCoordinator(
         
         foreach (var recommendedItem in recommendations.Recommended)
         {
-            // Get URL from the recommendation item
-            var recommendedUrl = recommendedItem.Url;
-            if (string.IsNullOrWhiteSpace(recommendedUrl)) continue;
-
-            if (!_streamIndexByUrl.TryGetValue(recommendedUrl, out var index))
-            {
-                var normalized = NormalizeStreamUrl(recommendedUrl);
-                if (!string.IsNullOrWhiteSpace(normalized))
-                {
-                    _streamIndexByUrl.TryGetValue(normalized, out index);
-                }
-            }
-
+            var index = ResolveRecommendationIndex(recommendedItem.Url, recommendedItem.StreamName);
             if (index < 0 || index >= totalStreams || !seen.Add(index))
             {
                 continue;
@@ -245,7 +242,39 @@ public class StreamSelectionCoordinator(
             }
         }
 
-        return ordered;
+        return StreamCatalogSourceOrderer.OrderIndexesFbBeforeMp(
+            ordered,
+            index => _candidates.First(c => c.Index == index).Stream);
+    }
+
+    private int ResolveRecommendationIndex(string recommendedUrl, string? recommendedStreamName)
+    {
+        if (!string.IsNullOrWhiteSpace(recommendedStreamName))
+        {
+            var compositeKey = StreamHealthIdentity.BuildStreamKey(recommendedUrl, recommendedStreamName);
+            if (_streamIndexByKey.TryGetValue(compositeKey, out var compositeIndex))
+            {
+                return compositeIndex;
+            }
+
+            var normalizedComposite = StreamHealthIdentity.BuildStreamKey(
+                StreamHealthIdentity.NormalizeStreamUrl(recommendedUrl),
+                recommendedStreamName);
+            if (_streamIndexByKey.TryGetValue(normalizedComposite, out compositeIndex))
+            {
+                return compositeIndex;
+            }
+        }
+
+        if (_streamIndexByKey.TryGetValue(recommendedUrl, out var index))
+        {
+            return index;
+        }
+
+        var normalized = StreamHealthIdentity.NormalizeStreamUrl(recommendedUrl);
+        return !string.IsNullOrWhiteSpace(normalized) && _streamIndexByKey.TryGetValue(normalized, out index)
+            ? index
+            : -1;
     }
 
     private void PublishProgress(
@@ -265,17 +294,5 @@ public class StreamSelectionCoordinator(
         };
 
         _progressSubject.OnNext(next);
-    }
-
-    private static string NormalizeStreamUrl(string url)
-    {
-        if (string.IsNullOrWhiteSpace(url)) return string.Empty;
-        if (Uri.TryCreate(url, UriKind.Absolute, out var uri))
-        {
-            return uri.GetLeftPart(UriPartial.Path);
-        }
-
-        var queryIndex = url.IndexOf('?');
-        return queryIndex >= 0 ? url[..queryIndex] : url;
     }
 }

--- a/VardyParty.Core/Parsers/BbcHtmlParser.cs
+++ b/VardyParty.Core/Parsers/BbcHtmlParser.cs
@@ -7,11 +7,25 @@ namespace VardyParty.Parsers;
 
 public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJsonParser) : IBbcHtmlParser
 {
-    private static readonly int Timeout = 200;
+    private static readonly int SlowGameWarnMs = 50;
+    // Real BBC event cards are ~2.5–4KB apart; cap avoids scanning hundreds of KB of trailing scripts.
+    private const int MaxGameBlockChars = 8192;
     private const string EscapedStartDateTimeMarker = "\\\"startDateTime\\\":\\\"";
     private const string EscapedIdMarker = "\\\"id\\\":\\\"";
     private const string UnescapedStartDateTimeMarker = "\"startDateTime\":\"";
     private const string UnescapedIdMarker = "\"id\":\"";
+    private const string DataEventIdMarker = "data-event-id=";
+    private const string H2Marker = "<h2";
+
+    private static readonly Regex AggScoreRegex = new(@"\(Agg\s+(?<h>\d+)\s*-\s*(?<a>\d+)\)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex AggScoreAltRegex = new(@"Aggregate\s+score[^<]*(?<h>\d+)\s*,[^<]*(?<a>\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex InjuryTimeApostropheRegex = new(@"(\d+)(?:&#x27;|&#39;|')\s*\+\s*(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex InjuryTimePlainRegex = new(@"(\d+)\s*\+\s*(\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex MinuteApostropheRegex = new(@"(?<m>\d+)\s*'", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex MinuteWordsRegex = new(@"(?<m>\d+)\s*minutes?", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex StyledPeriodMinuteRegex = new(@"<div[^>]*>(\d+)(?:&#x27;|&#39;|')</div>", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex PenaltiesWinRegex = new(@"(?<winner>[^<>\n]{1,100}?)\s+win\s+(?<w>\d+)\s*-\s*(?<l>\d+)\s+on\s+penalties", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+    private static readonly Regex OrdinalStatusRegex = new(@"\b\d+\s*(st|nd|rd|th)\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     // Simple, robust regex-based parser. Keeps memory footprint low.
     public List<BbcFixture> ParseHtml(string html, CancellationToken cancellationToken = default)
@@ -28,99 +42,15 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
         
         cancellationToken.ThrowIfCancellationRequested();
 
-        // Fallback: extract the JSON object following __INITIAL_DATA__ and scan it for id/status pairs
         if (eventStatusMap.Count == 0)
         {
-            var swFallback = System.Diagnostics.Stopwatch.StartNew();
-            try
-            {
-                int anchorIdx = -1;
-                var anchorNames = new[] { "window.__INITIAL_DATA__", "__INITIAL_DATA__" };
-                foreach (var a in anchorNames)
-                {
-                    anchorIdx = html.IndexOf(a, StringComparison.OrdinalIgnoreCase);
-                    if (anchorIdx >= 0) break;
-                }
-
-                if (anchorIdx >= 0)
-                {
-                    int braceStart = html.IndexOf('{', anchorIdx);
-                    if (braceStart >= 0)
-                    {
-                        bool inString = false;
-                        int depth = 0;
-                        int blobEnd = -1;
-                        for (int i = braceStart; i < html.Length; i++)
-                        {
-                            var c = html[i];
-                            if (c == '"')
-                            {
-                                int back = i - 1; bool esc = false; while (back >= 0 && html[back] == '\\') { esc = !esc; back--; }
-                                if (!esc) inString = !inString;
-                            }
-                            if (!inString)
-                            {
-                                if (c == '{') depth++;
-                                else if (c == '}')
-                                {
-                                    depth--;
-                                    if (depth == 0)
-                                    {
-                                        blobEnd = i;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-
-                        if (blobEnd > braceStart)
-                        {
-                            var jsonBlob = html.Substring(braceStart, blobEnd - braceStart + 1);
-                            var blobMatches = Regex.Matches(jsonBlob, "\"id\"\\s*:\\s*\"(?<id>s-[^\"']+)\"[\\s\\S]*?\"status\"\\s*:\\s*\"(?<s>[^\"']+)\"", RegexOptions.IgnoreCase);
-                            foreach (Match m in blobMatches)
-                            {
-                                try
-                                {
-                                    var id = m.Groups["id"].Value;
-                                    var s = m.Groups["s"].Value;
-                                    if (!string.IsNullOrEmpty(id) && !eventStatusMap.ContainsKey(id)) eventStatusMap[id] = (string.Empty, s, string.Empty);
-                                }
-                                catch { }
-                            }
-                        }
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                logger.LogWarning("[BBC] JSON fallback parse error: {Message}", ex.Message);
-            }
-            swFallback.Stop();
-            logger.LogInformation("[BBC] Fallback map build took {Elapsed}ms", swFallback.ElapsedMilliseconds);
+            logger.LogWarning("[BBC] Event status map empty after streaming parse; continuing with HTML-only status");
         }
 
-        // Final fallback: scan entire HTML for id/status pairs (covers custom initial JSON blocks)
-        if (eventStatusMap.Count == 0)
-        {
-            var rx = new Regex("\\\"id\\\"\\s*:\\s*\\\"(?<id>s-[^\\\"]+)\\\"[\\\\s\\\\S]*?\\\"status\\\"\\s*:\\s*\\\"(?<status>[^\\\"]+)\\\"", RegexOptions.IgnoreCase | RegexOptions.Multiline);
-            foreach (Match m in rx.Matches(html))
-            {
-                try
-                {
-                    var id = m.Groups["id"].Value;
-                    var s = m.Groups["status"].Value;
-                    if (!string.IsNullOrEmpty(id) && !eventStatusMap.ContainsKey(id))
-                    {
-                        eventStatusMap[id] = (string.Empty, s, string.Empty);
-                    }
-                }
-                catch { }
-            }
-        }
-
+        var swKickoff = System.Diagnostics.Stopwatch.StartNew();
         var eventKickoffMap = BuildEventKickoffMap(html);
+        swKickoff.Stop();
 
-        // --- NEW SERIAL SCANNER ---
         var swSerial = System.Diagnostics.Stopwatch.StartNew();
         try
         {
@@ -134,9 +64,14 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
 
         sw.Stop();
         
-        // Log "Serial" instead of BlockParse parts
-        logger.LogInformation("[BBC] Parsing stats: HeaderRx=0ms MapStream={Map}ms GameRx=0ms SerialScan={Serial}ms Total={Total}ms", 
-            swMap.ElapsedMilliseconds, swSerial.ElapsedMilliseconds, sw.ElapsedMilliseconds);
+        logger.LogInformation(
+            "[BBC] Parsing stats: MapStream={Map}ms StatusMap={StatusCount} KickoffMap={Kickoff}ms SerialScan={Serial}ms Fixtures={FixtureCount} Total={Total}ms",
+            swMap.ElapsedMilliseconds,
+            eventStatusMap.Count,
+            swKickoff.ElapsedMilliseconds,
+            swSerial.ElapsedMilliseconds,
+            list.Count,
+            sw.ElapsedMilliseconds);
 
         return list;
     }
@@ -215,81 +150,73 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
         Dictionary<string, (string periodLabel, string status, string statusComment)> eventStatusMap,
         Dictionary<string, DateTime> eventKickoffMap)
     {
-        // Single pass scanner
-        // We look for "<h2" or "data-event-id=" markers serially
+        // Single pass scanner over "<h2" / "data-event-id=" markers.
         int cursor = 0;
         string currentLeague = string.Empty;
         int len = html.Length;
-        int gamesFound = 0;
 
         while (cursor < len)
         {
-            // Find next interesting marker
-            // We search for "<h2" and "data-event-id="
-            int nextH2 = html.IndexOf("<h2", cursor, StringComparison.OrdinalIgnoreCase);
-            int nextGame = html.IndexOf("data-event-id=", cursor, StringComparison.OrdinalIgnoreCase);
+            int nextH2 = html.IndexOf(H2Marker, cursor, StringComparison.OrdinalIgnoreCase);
+            int nextGame = html.IndexOf(DataEventIdMarker, cursor, StringComparison.Ordinal);
 
-            if (nextH2 < 0 && nextGame < 0) break; // done
+            if (nextH2 < 0 && nextGame < 0) break;
 
-            // Determine which comes first
-            bool isHeader = false;
-            int foundIdx = -1;
-
+            bool isHeader;
+            int foundIdx;
             if (nextH2 >= 0 && nextGame >= 0)
             {
-                if (nextH2 < nextGame) { isHeader = true; foundIdx = nextH2; }
-                else { isHeader = false; foundIdx = nextGame; }
+                isHeader = nextH2 < nextGame;
+                foundIdx = isHeader ? nextH2 : nextGame;
             }
-            else if (nextH2 >= 0) { isHeader = true; foundIdx = nextH2; }
-            else { isHeader = false; foundIdx = nextGame; }
+            else if (nextH2 >= 0)
+            {
+                isHeader = true;
+                foundIdx = nextH2;
+            }
+            else
+            {
+                isHeader = false;
+                foundIdx = nextGame;
+            }
 
-            // Move cursor past the finding
             cursor = foundIdx;
 
             if (isHeader)
             {
-                // Parse League Header
-                // <h2 ...>Content</h2>
                 int endH2 = html.IndexOf("</h2>", cursor, StringComparison.OrdinalIgnoreCase);
                 if (endH2 > cursor)
                 {
-                    // Find closing '>' of open tag
                     int closeTag = html.IndexOf('>', cursor);
                     if (closeTag > cursor && closeTag < endH2)
                     {
                         var content = html.Substring(closeTag + 1, endH2 - closeTag - 1);
-                        var text = StripTags(content);
-                        text = System.Net.WebUtility.HtmlDecode(text);
+                        var text = System.Net.WebUtility.HtmlDecode(StripTags(content));
                         if (!string.IsNullOrWhiteSpace(text) && !text.Contains("Scores & Fixtures", StringComparison.OrdinalIgnoreCase))
                         {
                             currentLeague = text;
                         }
                     }
-                    cursor = endH2 + 5; // skip </h2>
+                    cursor = endH2 + 5;
                 }
                 else
                 {
-                    cursor += 4; // safety skip
+                    cursor += 4;
                 }
             }
             else
             {
-                // Parse Game
-                // data-event-id="s-..."
-                // We need to define scope. Where does this game block end?
-                // It ends at next "data-event-id=" OR next "<h2" OR a reasonable limit.
-                // Actually, we can just extract fields *forward* from here until we hit something or are happy.
-                // But better to define a 'limit' index to avoid scanning into next game.
-                
-                int nextMarker1 = html.IndexOf("data-event-id=", cursor + 14, StringComparison.OrdinalIgnoreCase);
-                int nextMarker2 = html.IndexOf("<h2", cursor + 14, StringComparison.OrdinalIgnoreCase);
-                int limit = len;
+                // Bound the card tightly. Without a cap, the last fixture scans hundreds of KB of trailing scripts.
+                int searchFrom = cursor + DataEventIdMarker.Length;
+                int cappedLimit = Math.Min(cursor + MaxGameBlockChars, len);
+                int nextMarker1 = html.IndexOf(DataEventIdMarker, searchFrom, StringComparison.Ordinal);
+                int nextMarker2 = html.IndexOf(H2Marker, searchFrom, StringComparison.OrdinalIgnoreCase);
+                int limit = cappedLimit;
                 if (nextMarker1 >= 0 && nextMarker1 < limit) limit = nextMarker1;
                 if (nextMarker2 >= 0 && nextMarker2 < limit) limit = nextMarker2;
 
-                // Extract ID
                 string id = "";
-                int quoteStart = html.IndexOf('"', cursor + 14); // after data-event-id=
+                int quoteStart = html.IndexOf('"', searchFrom);
                 if (quoteStart >= 0 && quoteStart < limit)
                 {
                     int quoteEnd = html.IndexOf('"', quoteStart + 1);
@@ -299,21 +226,18 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                     }
                 }
 
-                // If valid ID, extract details in range [cursor, limit)
                 if (!string.IsNullOrEmpty(id))
                 {
                     var swGame = System.Diagnostics.Stopwatch.StartNew();
-                    // Use helper that takes (html, start, end) to avoid substring
                     ParseGameNative(html, cursor, limit, id, currentLeague, list, eventStatusMap, eventKickoffMap);
                     swGame.Stop();
-                    if (swGame.ElapsedMilliseconds > Timeout)
+                    if (swGame.ElapsedMilliseconds > SlowGameWarnMs)
                     {
-                         logger.LogWarning("[BBC] Slow game parse ({Elapsed}ms) for ID {Id} in League {League}", swGame.ElapsedMilliseconds, id, currentLeague);
+                        logger.LogWarning("[BBC] Slow game parse ({Elapsed}ms) for ID {Id} in League {League}", swGame.ElapsedMilliseconds, id, currentLeague);
                     }
-                    gamesFound++;
                 }
 
-                cursor = limit; // jump to next item
+                cursor = limit;
             }
         }
     }
@@ -439,7 +363,7 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                 if (aggSearchLen > 0 && aggSearchLen < 5000)
                 {
                     var aggBlock = html.Substring(containerIdx, aggSearchLen);
-                    var aggMatch = Regex.Match(aggBlock, @"\(Agg\s+(?<h>\d+)\s*-\s*(?<a>\d+)\)", RegexOptions.IgnoreCase);
+                    var aggMatch = AggScoreRegex.Match(aggBlock);
                     if (aggMatch.Success)
                     {
                         aggHomeScore = TryParseInt(aggMatch.Groups["h"].Value);
@@ -447,7 +371,7 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                     }
                     else
                     {
-                        var aggMatch2 = Regex.Match(aggBlock, @"Aggregate\s+score[^<]*(?<h>\d+)\s*,[^<]*(?<a>\d+)", RegexOptions.IgnoreCase);
+                        var aggMatch2 = AggScoreAltRegex.Match(aggBlock);
                         if (aggMatch2.Success)
                         {
                             aggHomeScore = TryParseInt(aggMatch2.Groups["h"].Value);
@@ -460,14 +384,14 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
             if (!string.IsNullOrEmpty(progressInner))
             {
                 // First try: match injury time pattern with apostrophe before plus: 90'+8
-                var injPlus = Regex.Match(progressInner, @"(\d+)(?:&#x27;|&#39;|')\s*\+\s*(\d+)", RegexOptions.IgnoreCase);
-                
+                var injPlus = InjuryTimeApostropheRegex.Match(progressInner);
+
                 // If no apostrophe variant, try without apostrophe: 90+8
                 if (!injPlus.Success)
                 {
-                    injPlus = Regex.Match(progressInner, @"(\d+)\s*\+\s*(\d+)", RegexOptions.IgnoreCase);
+                    injPlus = InjuryTimePlainRegex.Match(progressInner);
                 }
-                
+
                 if (injPlus.Success)
                 {
                     var m = TryParseInt(injPlus.Groups[1].Value) ?? 0;
@@ -477,8 +401,8 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                 }
                 else
                 {
-                    var mMatch = Regex.Match(progressInner, @"(?<m>\d+)\s*'", RegexOptions.IgnoreCase);
-                    if (!mMatch.Success) mMatch = Regex.Match(progressInner, @"(?<m>\d+)\s*minutes", RegexOptions.IgnoreCase);
+                    var mMatch = MinuteApostropheRegex.Match(progressInner);
+                    if (!mMatch.Success) mMatch = MinuteWordsRegex.Match(progressInner);
                     if (mMatch.Success) minute = TryParseInt(mMatch.Groups["m"].Value);
                     if (minute.HasValue) minuteStatus = $"{minute}'";
                 }
@@ -495,12 +419,12 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                     // First, try to find injury time pattern in the container block
                     int containerBlockLen = minSearchLen;
                     var containerBlock = html.Substring(containerIdx, containerBlockLen);
-                    var injMatch = Regex.Match(containerBlock, @"(\d+)(?:&#x27;|&#39;|')\s*\+\s*(\d+)", RegexOptions.IgnoreCase);
+                    var injMatch = InjuryTimeApostropheRegex.Match(containerBlock);
                     if (!injMatch.Success)
                     {
-                        injMatch = Regex.Match(containerBlock, @"(\d+)\s*\+\s*(\d+)", RegexOptions.IgnoreCase);
+                        injMatch = InjuryTimePlainRegex.Match(containerBlock);
                     }
-                    
+
                     if (injMatch.Success)
                     {
                         var m = TryParseInt(injMatch.Groups[1].Value) ?? 0;
@@ -516,7 +440,7 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                         {
                             int periodEnd = Math.Min(styledIdx + 200, html.Length);
                             var periodBlock = html.Substring(styledIdx, periodEnd - styledIdx);
-                            var minMatch = Regex.Match(periodBlock, @"<div[^>]*>(\d+)(?:&#x27;|&#39;|')</div>", RegexOptions.IgnoreCase);
+                            var minMatch = StyledPeriodMinuteRegex.Match(periodBlock);
                             if (minMatch.Success)
                             {
                                 minute = TryParseInt(minMatch.Groups[1].Value);
@@ -631,7 +555,8 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
             if (firstBadgeIdx >= 0)
             {
                 // Scan back for http
-                int searchBackLimit = Math.Max(start, firstBadgeIdx - Timeout);
+                const int badgeHttpLookback = 200;
+                int searchBackLimit = Math.Max(start, firstBadgeIdx - badgeHttpLookback);
                 int httpIdx = html.LastIndexOf("http", firstBadgeIdx, firstBadgeIdx - searchBackLimit, StringComparison.OrdinalIgnoreCase);
                 if (httpIdx >= 0)
                 {
@@ -645,7 +570,7 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                         int secondBadgeIdx = FindBadgeExtension(searchStart2, end);
                         if (secondBadgeIdx >= 0)
                         {
-                             int searchBackLimit2 = Math.Max(start, secondBadgeIdx - Timeout);
+                             int searchBackLimit2 = Math.Max(start, secondBadgeIdx - badgeHttpLookback);
                              int http2Idx = html.LastIndexOf("http", secondBadgeIdx, secondBadgeIdx - searchBackLimit2, StringComparison.OrdinalIgnoreCase);
                              if (http2Idx >= 0)
                              {
@@ -688,7 +613,7 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                      // Last game on page could have rangeLen of 100KB+, causing 400ms+ regex penalty
                      int cappedRangeLen = Math.Min(rangeLen, 5000);
                      var blockSub = html.Substring(start, cappedRangeLen);
-                     var penMatch = Regex.Match(blockSub, @"(?<winner>[^<>\n]{1,100}?)\s+win\s+(?<w>\d+)\s*-\s*(?<l>\d+)\s+on\s+penalties", RegexOptions.IgnoreCase);
+                     var penMatch = PenaltiesWinRegex.Match(blockSub);
                      if (penMatch.Success)
                      {
                          penaltyWinner = System.Net.WebUtility.HtmlDecode(penMatch.Groups["winner"].Value.Trim());
@@ -732,7 +657,7 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                  {
                      var periodText = statusMap.periodLabel;
                      // Try to parse injury time format: "90+8'" or "90+8"
-                     var injMatch = Regex.Match(periodText, @"(\d+)\s*\+\s*(\d+)", RegexOptions.IgnoreCase);
+                     var injMatch = InjuryTimePlainRegex.Match(periodText);
                      if (injMatch.Success)
                      {
                          var m = TryParseInt(injMatch.Groups[1].Value) ?? 0;
@@ -745,10 +670,10 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                      else
                      {
                          // Try to parse simple minute format: "68'" or "68 minutes"
-                         var minMatch = Regex.Match(periodText, @"(\d+)\s*'", RegexOptions.IgnoreCase);
+                         var minMatch = MinuteApostropheRegex.Match(periodText);
                          if (!minMatch.Success)
                          {
-                             minMatch = Regex.Match(periodText, @"(\d+)\s*minutes?", RegexOptions.IgnoreCase);
+                             minMatch = MinuteWordsRegex.Match(periodText);
                          }
                          if (minMatch.Success)
                          {
@@ -763,11 +688,14 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                      }
                  }
                  
-                 if (string.IsNullOrEmpty(status) || status.Equals("", StringComparison.OrdinalIgnoreCase))
+                 if (string.IsNullOrEmpty(status))
                  {
-                     status = statusMap.status;
-                     if (status.IndexOf("Postponed", StringComparison.OrdinalIgnoreCase) >= 0)
+                     // BBC lifecycle enums (PreEvent/MidEvent/PostEvent) are not display statuses.
+                     // Only promote human-readable map statuses such as Postponed.
+                     var mapStatus = statusMap.status ?? string.Empty;
+                     if (mapStatus.IndexOf("Postponed", StringComparison.OrdinalIgnoreCase) >= 0)
                      {
+                         status = "Postponed";
                          isPostponed = true;
                          hasProgress = false;
                          isFinished = false;
@@ -775,8 +703,9 @@ public class BbcHtmlParser(ILogger<BbcHtmlParser> logger, IBbcJsonParser bbcJson
                          isHalf = false;
                          minute = null;
                      }
-                     else if (Regex.IsMatch(status, @"\b\d+\s*(st|nd|rd|th)\b", RegexOptions.IgnoreCase))
+                     else if (OrdinalStatusRegex.IsMatch(mapStatus))
                      {
+                         status = mapStatus;
                          minute = 0;
                      }
                  }

--- a/VardyParty.Core/Parsers/BbcJsonParser.cs
+++ b/VardyParty.Core/Parsers/BbcJsonParser.cs
@@ -8,6 +8,18 @@ public class BbcJsonParser : IBbcJsonParser
 {
     private readonly ILogger<BbcJsonParser> _logger;
 
+    // BBC currently embeds __INITIAL_DATA__ as an escaped JSON string:
+    //   __INITIAL_DATA__="{\"data\":...,\"id\":\"s-...\",\"status\":\"PostEvent\",...}"
+    private const string EscapedIdMarker = "\\\"id\\\":\\\"";
+    private const string EscapedStatusMarker = "\\\"status\\\":\\\"";
+    private const string EscapedPeriodValueMarker = "\\\"periodLabel\\\":{\\\"value\\\":\\\"";
+    private const string EscapedStatusCommentValueMarker = "\\\"statusComment\\\":{\\\"value\\\":\\\"";
+    private const string EscapedStringEnd = "\\\"";
+
+    private const string UnescapedIdMarker = "\"id\":\"s-";
+    private const int EventFieldWindow = 3000;
+    private const int MaxObjects = 5000;
+
     public BbcJsonParser(ILogger<BbcJsonParser>? logger = null)
     {
         _logger = logger ?? NullLogger<BbcJsonParser>.Instance;
@@ -15,96 +27,24 @@ public class BbcJsonParser : IBbcJsonParser
 
     public Dictionary<string, (string periodLabel, string status, string statusComment)> BuildEventStatusMapStreaming(string html, CancellationToken cancellationToken = default)
     {
-        var map = new Dictionary<string, (string periodLabel, string status, string statusComment)>();
+        var map = new Dictionary<string, (string periodLabel, string status, string statusComment)>(StringComparer.OrdinalIgnoreCase);
         if (string.IsNullOrEmpty(html)) return map;
 
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
-            var anchorNames = new[] { "window.__INITIAL_DATA__", "__INITIAL_DATA__" };
-            int anchorIdx = -1;
-            foreach (var a in anchorNames)
+
+            var searchStart = 0;
+            var anchorIdx = html.IndexOf("__INITIAL_DATA__", StringComparison.OrdinalIgnoreCase);
+            if (anchorIdx >= 0) searchStart = anchorIdx;
+
+            // Real BBC pages use escaped JSON inside a quoted JS/HTML string.
+            ExtractEscapedEventStatuses(html, searchStart, map, cancellationToken);
+
+            // Unit tests / older markup may embed raw JSON objects.
+            if (map.Count == 0)
             {
-                anchorIdx = html.IndexOf(a, StringComparison.OrdinalIgnoreCase);
-                if (anchorIdx >= 0) break;
-            }
-            if (anchorIdx < 0) return map;
-
-            int braceStart = html.IndexOf('{', anchorIdx);
-            if (braceStart < 0) return map;
-
-            int searchPos = braceStart;
-            int found = 0;
-            const int MaxObjects = 5000; // safety
-
-            while (true)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-                int idPos = html.IndexOf("\"id\":\"s-", searchPos, StringComparison.OrdinalIgnoreCase);
-                if (idPos < 0) break;
-
-                int objStart = html.LastIndexOf('{', idPos);
-
-                if (objStart < braceStart) break;
-
-                int depth = 0;
-                bool inString = false;
-                int objEnd = -1;
-                for (int i = objStart; i < html.Length; i++)
-                {
-                    char c = html[i];
-                    if (c == '\"')
-                    {
-                        int back = i - 1; bool esc = false; while (back >= 0 && html[back] == '\\') { esc = !esc; back--; }
-                        if (!esc) inString = !inString;
-                    }
-                    if (!inString)
-                    {
-                        if (c == '{') depth++;
-                        else if (c == '}')
-                        {
-                            depth--;
-                            if (depth == 0)
-                            {
-                                objEnd = i;
-                                break;
-                            }
-                        }
-                    }
-                }
-
-                if (objEnd <= objStart || objEnd < 0) break;
-
-                var objJson = html.Substring(objStart, objEnd - objStart + 1);
-                try
-                {
-                    using var doc = JsonDocument.Parse(objJson);
-                    var root = doc.RootElement;
-                    if (root.ValueKind == JsonValueKind.Object)
-                    {
-                        if (root.TryGetProperty("id", out var idProp) && idProp.ValueKind == JsonValueKind.String)
-                        {
-                            var id = idProp.GetString() ?? string.Empty;
-                            if (!string.IsNullOrEmpty(id) && id.StartsWith("s-"))
-                            {
-                                string period = string.Empty, status = string.Empty, statusComment = string.Empty;
-                                if (root.TryGetProperty("periodLabel", out var pl) && pl.ValueKind == JsonValueKind.Object && pl.TryGetProperty("value", out var pv)) period = pv.GetString() ?? string.Empty;
-                                if (root.TryGetProperty("status", out var st) && st.ValueKind == JsonValueKind.String) status = st.GetString() ?? string.Empty;
-                                if (root.TryGetProperty("statusComment", out var sc) && sc.ValueKind == JsonValueKind.Object && sc.TryGetProperty("value", out var scv)) statusComment = scv.GetString() ?? string.Empty;
-                                if (!map.ContainsKey(id)) map[id] = (period, status, statusComment);
-                            }
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "[BBC] Failed to parse event JSON object");
-                }
-
-                found++;
-                if (found >= MaxObjects) break;
-
-                searchPos = objEnd + 1;
+                ExtractUnescapedEventStatuses(html, searchStart, map, cancellationToken);
             }
         }
         catch (Exception ex)
@@ -113,5 +53,184 @@ public class BbcJsonParser : IBbcJsonParser
         }
 
         return map;
+    }
+
+    private void ExtractEscapedEventStatuses(
+        string html,
+        int searchStart,
+        Dictionary<string, (string periodLabel, string status, string statusComment)> map,
+        CancellationToken cancellationToken)
+    {
+        var pos = searchStart;
+        var found = 0;
+
+        while (found < MaxObjects)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var idMarkerPos = html.IndexOf(EscapedIdMarker, pos, StringComparison.Ordinal);
+            if (idMarkerPos < 0) break;
+
+            var idStart = idMarkerPos + EscapedIdMarker.Length;
+            if (idStart + 2 >= html.Length || html[idStart] != 's' || html[idStart + 1] != '-')
+            {
+                pos = idMarkerPos + EscapedIdMarker.Length;
+                continue;
+            }
+
+            var idEnd = html.IndexOf(EscapedStringEnd, idStart, StringComparison.Ordinal);
+            if (idEnd <= idStart)
+            {
+                pos = idStart + 1;
+                continue;
+            }
+
+            var id = html.Substring(idStart, idEnd - idStart);
+            var windowEnd = Math.Min(html.Length, idMarkerPos + EventFieldWindow);
+            var windowLen = windowEnd - idMarkerPos;
+
+            var status = ExtractEscapedStringValue(html, EscapedStatusMarker, idMarkerPos, windowLen);
+            var period = ExtractEscapedStringValue(html, EscapedPeriodValueMarker, idMarkerPos, windowLen);
+            var statusComment = ExtractEscapedStringValue(html, EscapedStatusCommentValueMarker, idMarkerPos, windowLen);
+
+            // Only keep event-like objects that expose a status field.
+            if (!string.IsNullOrEmpty(status) && !map.ContainsKey(id))
+            {
+                map[id] = (period, status, statusComment);
+                found++;
+            }
+
+            pos = idEnd + EscapedStringEnd.Length;
+        }
+    }
+
+    private static string ExtractEscapedStringValue(string html, string marker, int searchStart, int searchLength)
+    {
+        if (searchLength <= 0) return string.Empty;
+
+        var markerPos = html.IndexOf(marker, searchStart, searchLength, StringComparison.Ordinal);
+        if (markerPos < 0) return string.Empty;
+
+        var valueStart = markerPos + marker.Length;
+        var remaining = searchStart + searchLength - valueStart;
+        if (remaining <= 0) return string.Empty;
+
+        var valueEnd = html.IndexOf(EscapedStringEnd, valueStart, remaining, StringComparison.Ordinal);
+        if (valueEnd <= valueStart) return string.Empty;
+
+        return html.Substring(valueStart, valueEnd - valueStart);
+    }
+
+    private void ExtractUnescapedEventStatuses(
+        string html,
+        int searchStart,
+        Dictionary<string, (string periodLabel, string status, string statusComment)> map,
+        CancellationToken cancellationToken)
+    {
+        var searchPos = searchStart;
+        var found = 0;
+
+        while (found < MaxObjects)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var idPos = html.IndexOf(UnescapedIdMarker, searchPos, StringComparison.Ordinal);
+            if (idPos < 0) break;
+
+            var objStart = html.LastIndexOf('{', idPos);
+            if (objStart < searchStart)
+            {
+                searchPos = idPos + UnescapedIdMarker.Length;
+                continue;
+            }
+
+            var objEnd = FindJsonObjectEnd(html, objStart);
+            if (objEnd <= objStart)
+            {
+                searchPos = idPos + UnescapedIdMarker.Length;
+                continue;
+            }
+
+            var objJson = html.Substring(objStart, objEnd - objStart + 1);
+            try
+            {
+                using var doc = JsonDocument.Parse(objJson);
+                var root = doc.RootElement;
+                if (root.ValueKind == JsonValueKind.Object
+                    && root.TryGetProperty("id", out var idProp)
+                    && idProp.ValueKind == JsonValueKind.String)
+                {
+                    var id = idProp.GetString() ?? string.Empty;
+                    if (!string.IsNullOrEmpty(id) && id.StartsWith("s-", StringComparison.Ordinal))
+                    {
+                        var period = string.Empty;
+                        var status = string.Empty;
+                        var statusComment = string.Empty;
+                        if (root.TryGetProperty("periodLabel", out var pl)
+                            && pl.ValueKind == JsonValueKind.Object
+                            && pl.TryGetProperty("value", out var pv))
+                        {
+                            period = pv.GetString() ?? string.Empty;
+                        }
+
+                        if (root.TryGetProperty("status", out var st) && st.ValueKind == JsonValueKind.String)
+                        {
+                            status = st.GetString() ?? string.Empty;
+                        }
+
+                        if (root.TryGetProperty("statusComment", out var sc)
+                            && sc.ValueKind == JsonValueKind.Object
+                            && sc.TryGetProperty("value", out var scv))
+                        {
+                            statusComment = scv.GetString() ?? string.Empty;
+                        }
+
+                        if (!map.ContainsKey(id))
+                        {
+                            map[id] = (period, status, statusComment);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "[BBC] Failed to parse event JSON object");
+            }
+
+            found++;
+            searchPos = objEnd + 1;
+        }
+    }
+
+    private static int FindJsonObjectEnd(string html, int objStart)
+    {
+        var depth = 0;
+        var inString = false;
+        for (var i = objStart; i < html.Length; i++)
+        {
+            var c = html[i];
+            if (c == '"')
+            {
+                var back = i - 1;
+                var esc = false;
+                while (back >= 0 && html[back] == '\\')
+                {
+                    esc = !esc;
+                    back--;
+                }
+
+                if (!esc) inString = !inString;
+            }
+
+            if (inString) continue;
+
+            if (c == '{') depth++;
+            else if (c == '}')
+            {
+                depth--;
+                if (depth == 0) return i;
+            }
+        }
+
+        return -1;
     }
 }

--- a/VardyParty.Core/Resolvers/StreamCatalogSourceOrderer.cs
+++ b/VardyParty.Core/Resolvers/StreamCatalogSourceOrderer.cs
@@ -1,0 +1,58 @@
+using StreamModel = VardyParty.Models.Stream;
+
+namespace VardyParty.Resolvers;
+
+/// <summary>
+/// Orders catalog streams so FB (English footybitex) candidates are tried before MP (v2) alternates.
+/// </summary>
+public static class StreamCatalogSourceOrderer
+{
+    public static List<StreamModel> OrderFbBeforeMp(IEnumerable<StreamModel> streams)
+    {
+        return streams
+            .Select((stream, index) => (stream, index))
+            .OrderBy(x => GetCatalogSourcePriority(x.stream))
+            .ThenBy(x => x.index)
+            .Select(x => x.stream)
+            .ToList();
+    }
+
+    public static List<int> OrderIndexesFbBeforeMp(
+        IReadOnlyList<int> indexes,
+        Func<int, StreamModel> getStream)
+    {
+        var fb = new List<int>();
+        var other = new List<int>();
+        var mp = new List<int>();
+
+        foreach (var index in indexes)
+        {
+            switch (getStream(index).ResolveCatalogSource())
+            {
+                case "fb":
+                    fb.Add(index);
+                    break;
+                case "mp":
+                    mp.Add(index);
+                    break;
+                default:
+                    other.Add(index);
+                    break;
+            }
+        }
+
+        var ordered = new List<int>(indexes.Count);
+        ordered.AddRange(fb);
+        ordered.AddRange(other);
+        ordered.AddRange(mp);
+        return ordered;
+    }
+
+    internal static int GetCatalogSourcePriority(StreamModel stream) =>
+        stream.ResolveCatalogSource() switch
+        {
+            "fb" => 0,
+            "mp" => 1,
+            _ => 2
+        };
+}

--- a/VardyParty.Core/Resolvers/StreamDeduplicator.cs
+++ b/VardyParty.Core/Resolvers/StreamDeduplicator.cs
@@ -26,17 +26,17 @@ public class StreamDeduplicator(ILogger<StreamDeduplicator> logger) : IStreamDed
 
         var groupedByBaseUrl = new Dictionary<string, List<Models.Stream>>(StringComparer.OrdinalIgnoreCase);
 
-        // Group streams by their base URL
+        // Group streams by their base URL (and player label for v2 multi-stream pages)
         foreach (var stream in streams)
         {
-            var baseUrl = ExtractBaseUrl(stream.Url);
+            var dedupKey = GetDedupKey(stream);
             
-            if (!groupedByBaseUrl.ContainsKey(baseUrl))
+            if (!groupedByBaseUrl.ContainsKey(dedupKey))
             {
-                groupedByBaseUrl[baseUrl] = new List<Models.Stream>();
+                groupedByBaseUrl[dedupKey] = new List<Models.Stream>();
             }
             
-            groupedByBaseUrl[baseUrl].Add(stream);
+            groupedByBaseUrl[dedupKey].Add(stream);
         }
 
         // Select best stream from each group
@@ -59,14 +59,32 @@ public class StreamDeduplicator(ILogger<StreamDeduplicator> logger) : IStreamDed
 
     public string ExtractBaseUrl(string url) => StreamUrlNormalizer.NormalizeForDedup(url);
 
+    private static string GetDedupKey(Models.Stream stream)
+    {
+        var baseUrl = StreamUrlNormalizer.NormalizeForDedup(stream.Url);
+        if (!stream.RequiresV2StreamSelection)
+        {
+            return baseUrl;
+        }
+
+        var playerLabel = string.IsNullOrWhiteSpace(stream.PlayerStream)
+            ? stream.Channel
+            : stream.PlayerStream;
+
+        return string.IsNullOrWhiteSpace(playerLabel)
+            ? baseUrl
+            : $"{baseUrl}\0{playerLabel.Trim()}";
+    }
+
     private Models.Stream SelectBestStream(List<Models.Stream> group)
     {
         if (group.Count == 1)
             return group[0];
 
-        // Sort by reputation score (highest first), then by channel name
+        // Sort by reputation score (highest first), then FB before MP, then by channel name
         var sorted = group
             .OrderByDescending(s => GetReputationScore(s.Reputation))
+            .ThenBy(s => StreamCatalogSourceOrderer.GetCatalogSourcePriority(s))
             .ThenBy(s => s.Channel, StringComparer.OrdinalIgnoreCase)
             .ToList();
 

--- a/VardyParty.Core/Resolvers/StreamResolver.cs
+++ b/VardyParty.Core/Resolvers/StreamResolver.cs
@@ -44,26 +44,15 @@ public class StreamResolver(
             logger.LogInformation("[StreamResolver] Processing batch {BatchNumber} with {Count} streams",
                 i / batchSize + 1, batch.Count);
 
-            // Resolve and test each stream in the batch in parallel
+            // Resolve streams in parallel but yield in input order so catalog priority is preserved.
             var tasks = batch.Select(stream => ResolveAndTestStreamAsync(stream, cancellationToken)).ToList();
+            var results = await Task.WhenAll(tasks);
 
-            // As each completes, yield it immediately (not waiting for whole batch)
-            var completed = new HashSet<Task>();
-            while (completed.Count < tasks.Count)
+            foreach (var enriched in results)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var nextCompleted = await Task.WhenAny(tasks.Except(completed).ToList());
-                completed.Add(nextCompleted);
-
-                // Get the result and yield it
-                if (nextCompleted is Task<EnrichedStream> task)
-                {
-                    var enriched = await task;
-                    logger.LogInformation("[StreamResolver] Yielding resolved stream: {Channel} ({Status})",
-                        enriched.Stream.Channel, enriched.Status);
-                    yield return enriched;
-                }
+                logger.LogInformation("[StreamResolver] Yielding resolved stream: {Channel} ({Status})",
+                    enriched.Stream.Channel, enriched.Status);
+                yield return enriched;
             }
         }
 
@@ -122,7 +111,8 @@ public class StreamResolver(
         {
             // Step 1: Resolve m3u8 URL
             logger.LogInformation("[StreamResolver] Resolving m3u8 for {Channel}", stream.Channel);
-            var m3u8Url = await GetM3U8UrlInternalAsync(stream, cancellationToken);
+            var m3u8Response = await ResolveM3U8ResponseInternalAsync(stream, cancellationToken);
+            var m3u8Url = m3u8Response?.Url;
 
             if (string.IsNullOrEmpty(m3u8Url))
             {
@@ -135,7 +125,8 @@ public class StreamResolver(
 
             enriched.ResolvedM3U8Url = m3u8Url;
             enriched.Status = StreamResolutionStatus.Resolved;
-            enriched.Referer = stream.Url;
+            enriched.RequestHeaders = m3u8Response?.RequestHeaders;
+            enriched.Referer = ResolveReferer(m3u8Response, stream.Url);
             logger.LogInformation("[StreamResolver] Resolved m3u8 for {Channel}: {Url}", stream.Channel, m3u8Url);
 
             // Step 2: Test health and extract metadata
@@ -144,17 +135,23 @@ public class StreamResolver(
             logger.LogInformation("[StreamResolver] Using referer for health check: {Referer}", enriched.Referer);
             var health = await healthChecker.CheckStreamHealthAsync(m3u8Url, enriched.Referer, cancellationToken);
             enriched.Health = health;
-            enriched.Status = health.Status == StreamHealthStatus.Healthy
-                ? StreamResolutionStatus.Healthy
-                : StreamResolutionStatus.Failed;
-
-            if (enriched.Status == StreamResolutionStatus.Healthy)
+            if (health.Status == StreamHealthStatus.Healthy)
             {
+                enriched.Status = StreamResolutionStatus.Healthy;
                 logger.LogInformation("[StreamResolver] Stream {Channel} is healthy: {Quality}",
                     stream.Channel, health.GetQualityLabel());
             }
+            else if (health.Status is StreamHealthStatus.SegmentUnreachable or StreamHealthStatus.ManifestUnreachable)
+            {
+                // LocalService already resolved a live m3u8 via Playwright; client CDN probes often fail HEAD/referrer checks.
+                enriched.Status = StreamResolutionStatus.Healthy;
+                logger.LogWarning(
+                    "[StreamResolver] Health probe reported {Status} for {Channel}; trusting LocalService m3u8 for playback",
+                    health.Status, stream.Channel);
+            }
             else
             {
+                enriched.Status = StreamResolutionStatus.Failed;
                 enriched.ErrorMessage = $"Health check failed: {health.Status}";
                 logger.LogWarning("[StreamResolver] Stream {Channel} failed health check: {Status}",
                     stream.Channel, health.Status);
@@ -189,6 +186,12 @@ public class StreamResolver(
 
     private async Task<string?> GetM3U8UrlInternalAsync(Stream stream, CancellationToken cancellationToken)
     {
+        var response = await ResolveM3U8ResponseInternalAsync(stream, cancellationToken);
+        return response?.Url;
+    }
+
+    private async Task<M3U8Response?> ResolveM3U8ResponseInternalAsync(Stream stream, CancellationToken cancellationToken)
+    {
         try
         {
             var playerStreamName = GetPlayerStreamName(stream);
@@ -198,12 +201,37 @@ public class StreamResolver(
                 playerStreamName is null ? "" : $" (stream={playerStreamName})");
             var result = await localLanPlayService.ResolveM3U8UrlAsync(stream.Url, playerStreamName, cancellationToken);
             logger.LogInformation("[StreamResolver] M3U8 resolve completed for source {Url}", stream.Url);
-            return result?.Url;
+            return result;
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "[StreamResolver] Failed to fetch M3U8 for {Url}", stream.Url);
             return null;
         }
+    }
+
+    private static string ResolveReferer(M3U8Response? response, string fallbackUrl)
+    {
+        var capturedReferer = GetHeaderValue(response?.RequestHeaders, "referer");
+        return string.IsNullOrWhiteSpace(capturedReferer) ? fallbackUrl : capturedReferer;
+    }
+
+    private static string? GetHeaderValue(IReadOnlyDictionary<string, string>? headers, string headerName)
+    {
+        if (headers is null || headers.Count == 0)
+        {
+            return null;
+        }
+
+        foreach (var pair in headers)
+        {
+            if (pair.Key.Equals(headerName, StringComparison.OrdinalIgnoreCase)
+                && !string.IsNullOrWhiteSpace(pair.Value))
+            {
+                return pair.Value;
+            }
+        }
+
+        return null;
     }
 }

--- a/VardyParty.Core/Resolvers/StreamResolver.cs
+++ b/VardyParty.Core/Resolvers/StreamResolver.cs
@@ -79,7 +79,7 @@ public class StreamResolver(
         {
             logger.LogInformation("[StreamResolver] Resolving m3u8 URL for single stream: {Channel}", stream.Channel);
 
-            var m3u8Url = await GetM3U8UrlInternalAsync(stream.Url, cancellationToken);
+            var m3u8Url = await GetM3U8UrlInternalAsync(stream, cancellationToken);
 
             if (!string.IsNullOrEmpty(m3u8Url))
             {
@@ -110,11 +110,19 @@ public class StreamResolver(
     {
         var enriched = new EnrichedStream { Stream = stream, Status = StreamResolutionStatus.Pending };
 
+        if (stream.IsCountdown)
+        {
+            enriched.Status = StreamResolutionStatus.Failed;
+            enriched.ErrorMessage = "Stream page is in countdown (not started yet)";
+            logger.LogInformation("[StreamResolver] Skipping {Channel}: countdown active on stream page", stream.Channel);
+            return enriched;
+        }
+
         try
         {
             // Step 1: Resolve m3u8 URL
             logger.LogInformation("[StreamResolver] Resolving m3u8 for {Channel}", stream.Channel);
-            var m3u8Url = await GetM3U8UrlInternalAsync(stream.Url, cancellationToken);
+            var m3u8Url = await GetM3U8UrlInternalAsync(stream, cancellationToken);
 
             if (string.IsNullOrEmpty(m3u8Url))
             {
@@ -164,18 +172,37 @@ public class StreamResolver(
         }
     }
 
-    private async Task<string?> GetM3U8UrlInternalAsync(string streamUrl, CancellationToken cancellationToken)
+    private static string? GetPlayerStreamName(Stream stream)
+    {
+        if (!stream.RequiresV2StreamSelection || stream.IsCountdown)
+        {
+            return null;
+        }
+
+        if (!string.IsNullOrWhiteSpace(stream.PlayerStream))
+        {
+            return stream.PlayerStream.Trim();
+        }
+
+        return string.IsNullOrWhiteSpace(stream.Channel) ? null : stream.Channel.Trim();
+    }
+
+    private async Task<string?> GetM3U8UrlInternalAsync(Stream stream, CancellationToken cancellationToken)
     {
         try
         {
-            logger.LogInformation("[StreamResolver] Fetching M3U8 from local LAN service for source {Url}", streamUrl);
-            var result = await localLanPlayService.ResolveM3U8UrlAsync(streamUrl, cancellationToken);
-            logger.LogInformation("[StreamResolver] M3U8 resolve completed for source {Url}", streamUrl);
+            var playerStreamName = GetPlayerStreamName(stream);
+            logger.LogInformation(
+                "[StreamResolver] Fetching M3U8 from local LAN service for source {Url}{StreamSuffix}",
+                stream.Url,
+                playerStreamName is null ? "" : $" (stream={playerStreamName})");
+            var result = await localLanPlayService.ResolveM3U8UrlAsync(stream.Url, playerStreamName, cancellationToken);
+            logger.LogInformation("[StreamResolver] M3U8 resolve completed for source {Url}", stream.Url);
             return result?.Url;
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "[StreamResolver] Failed to fetch M3U8 for {Url}", streamUrl);
+            logger.LogError(ex, "[StreamResolver] Failed to fetch M3U8 for {Url}", stream.Url);
             return null;
         }
     }

--- a/VardyParty.Core/Resolvers/V2StreamExpander.cs
+++ b/VardyParty.Core/Resolvers/V2StreamExpander.cs
@@ -5,6 +5,7 @@ namespace VardyParty.Resolvers;
 
 /// <summary>
 /// Expands v2 API stream entries (one page URL, many player labels) into per-label candidates.
+/// v2 rows with no player-stream labels are dropped — an empty MP page shell is not testable.
 /// </summary>
 public static class V2StreamExpander
 {
@@ -21,15 +22,18 @@ public static class V2StreamExpander
                     .Distinct(StringComparer.OrdinalIgnoreCase)
                     .ToList();
 
-                if (labels.Count > 0)
+                // No labels => not a real MP candidate (matches API isV2StreamPlayable).
+                if (labels.Count == 0)
                 {
-                    foreach (var label in labels)
-                    {
-                        expanded.Add(CloneWithPlayerStream(stream, label));
-                    }
-
                     continue;
                 }
+
+                foreach (var label in labels)
+                {
+                    expanded.Add(CloneWithPlayerStream(stream, label));
+                }
+
+                continue;
             }
 
             expanded.Add(stream);

--- a/VardyParty.Core/Resolvers/V2StreamExpander.cs
+++ b/VardyParty.Core/Resolvers/V2StreamExpander.cs
@@ -1,0 +1,57 @@
+using VardyParty.Models;
+using StreamModel = VardyParty.Models.Stream;
+
+namespace VardyParty.Resolvers;
+
+/// <summary>
+/// Expands v2 API stream entries (one page URL, many player labels) into per-label candidates.
+/// </summary>
+public static class V2StreamExpander
+{
+    public static List<StreamModel> Expand(IEnumerable<StreamModel> streams)
+    {
+        var expanded = new List<StreamModel>();
+        foreach (var stream in streams)
+        {
+            if (stream.RequiresV2StreamSelection)
+            {
+                var labels = stream.PlayerStreams
+                    .Where(label => !string.IsNullOrWhiteSpace(label))
+                    .Select(label => label.Trim())
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+
+                if (labels.Count > 0)
+                {
+                    foreach (var label in labels)
+                    {
+                        expanded.Add(CloneWithPlayerStream(stream, label));
+                    }
+
+                    continue;
+                }
+            }
+
+            expanded.Add(stream);
+        }
+
+        return expanded;
+    }
+
+    private static StreamModel CloneWithPlayerStream(StreamModel source, string playerStreamLabel) =>
+        new()
+        {
+            Url = source.Url,
+            Channel = playerStreamLabel,
+            PlayerStream = playerStreamLabel,
+            ResolutionStrategy = source.ResolutionStrategy,
+            Reputation = source.Reputation,
+            Quality = source.Quality,
+            Language = source.Language,
+            Ads = source.Ads,
+            StreamStatus = source.StreamStatus,
+            PlayerStreams = source.PlayerStreams,
+            BitrateKbps = source.BitrateKbps,
+            Resolution = source.Resolution
+        };
+}

--- a/VardyParty.Core/Services/ApiService.cs
+++ b/VardyParty.Core/Services/ApiService.cs
@@ -197,12 +197,15 @@ public class ApiService(
             yield break;
         }
 
+        var expandedStreams = StreamCatalogSourceOrderer.OrderFbBeforeMp(
+            V2StreamExpander.Expand(response.Streams));
+
         // Deduplicate streams by base m3u8 URL
         List<Stream> deduplicated;
         try
         {
-            logger.LogInformation("[Api] Deduplicating {Count} streams", response.Streams.Count);
-            deduplicated = streamDeduplicator.DeduplicateStreams(response.Streams);
+            logger.LogInformation("[Api] Deduplicating {Count} streams", expandedStreams.Count);
+            deduplicated = streamDeduplicator.DeduplicateStreams(expandedStreams);
             logger.LogInformation("[Api] Starting incremental resolution of {Count} deduplicated streams",
                 deduplicated.Count);
         }

--- a/VardyParty.Core/Services/ApiService.cs
+++ b/VardyParty.Core/Services/ApiService.cs
@@ -45,10 +45,17 @@ public class ApiService(
 
     public async Task<M3U8Response?> GetM3U8UrlAsync(string streamUrl)
     {
+        return await GetM3U8UrlAsync(streamUrl, playerStreamName: null);
+    }
+
+    public async Task<M3U8Response?> GetM3U8UrlAsync(string streamUrl, string? playerStreamName)
+    {
         try
         {
-            logger.LogInformation("[Api] Fetching M3U8 from local LAN service for source {Url}", streamUrl);
-            var result = await localLanPlayService.ResolveM3U8UrlAsync(streamUrl);
+            logger.LogInformation("[Api] Fetching M3U8 from local LAN service for source {Url}{StreamSuffix}",
+                streamUrl,
+                string.IsNullOrWhiteSpace(playerStreamName) ? "" : $" (stream={playerStreamName})");
+            var result = await localLanPlayService.ResolveM3U8UrlAsync(streamUrl, playerStreamName);
             if (!string.IsNullOrEmpty(result?.Url))
             {
                 logger.LogInformation("[Api] M3U8 fetched for {Url}", streamUrl);
@@ -74,7 +81,10 @@ public class ApiService(
         try
         {
             logger.LogInformation("[Api] Resolving m3u8 for playback: {Channel}", stream.Channel);
-            var m3u8Response = await GetM3U8UrlAsync(stream.Url);
+            var playerStreamName = stream.RequiresV2StreamSelection && !stream.IsCountdown
+                ? (string.IsNullOrWhiteSpace(stream.PlayerStream) ? stream.Channel : stream.PlayerStream)
+                : null;
+            var m3u8Response = await GetM3U8UrlAsync(stream.Url, playerStreamName);
 
             if (m3u8Response != null && !string.IsNullOrEmpty(m3u8Response.Url))
             {

--- a/VardyParty.Core/Services/HomePagePresentationService.cs
+++ b/VardyParty.Core/Services/HomePagePresentationService.cs
@@ -6,39 +6,57 @@ using VardyParty.Models;
 
 namespace VardyParty.Services;
 
-    public interface IHomePagePresentationService
+public interface IHomePagePresentationService
+{
+    IObservable<List<Game>> DisplayStream { get; }
+}
+
+public class HomePagePresentationService : IHomePagePresentationService, IDisposable
+{
+    private readonly Subject<List<Game>> _subject = new Subject<List<Game>>();
+    private readonly IDisposable _subscription;
+    private readonly ILeagueFilterService _leagueFilter;
+    private Dictionary<string, List<Game>>? _latestSnapshot;
+
+    public IObservable<List<Game>> DisplayStream => _subject;
+
+    public HomePagePresentationService(IEnrichedGameService enriched, ILeagueFilterService leagueFilter)
     {
-        IObservable<List<Game>> DisplayStream { get; }
+        if (enriched == null) throw new ArgumentNullException(nameof(enriched));
+        _leagueFilter = leagueFilter ?? throw new ArgumentNullException(nameof(leagueFilter));
+
+        _leagueFilter.Changed += OnLeagueFilterChanged;
+
+        _subscription = enriched.GamesStream.Subscribe(dict =>
+        {
+            _latestSnapshot = dict;
+            PublishDisplay();
+        });
     }
 
-    public class HomePagePresentationService : IHomePagePresentationService, IDisposable
+    private void OnLeagueFilterChanged()
     {
-        private readonly Subject<List<Game>> _subject = new Subject<List<Game>>();
-        public IObservable<List<Game>> DisplayStream => _subject;
+        PublishDisplay();
+    }
 
-        private readonly IDisposable _subscription;
-
-        public HomePagePresentationService(IEnrichedGameService enriched)
+    private void PublishDisplay()
+    {
+        try
         {
-            if (enriched == null) throw new ArgumentNullException(nameof(enriched));
-
-            _subscription = enriched.GamesStream.Subscribe(dict =>
-            {
-                try
-                {
-                    var display = dict?.ToDisplay() ?? new List<Game>();
-                    _subject.OnNext(display);
-                }
-                catch (Exception)
-                {
-                    // swallow - presentation should be robust; optionally log if logger available
-                }
-            });
+            var display = _latestSnapshot?.ToDisplay() ?? new List<Game>();
+            var filtered = _leagueFilter.FilterGames(display);
+            _subject.OnNext(filtered);
         }
-
-        public void Dispose()
+        catch (Exception)
         {
-            _subscription.Dispose();
-            _subject.Dispose();
+            // swallow - presentation should be robust; optionally log if logger available
         }
     }
+
+    public void Dispose()
+    {
+        _leagueFilter.Changed -= OnLeagueFilterChanged;
+        _subscription.Dispose();
+        _subject.Dispose();
+    }
+}

--- a/VardyParty.Core/Services/IApiService.cs
+++ b/VardyParty.Core/Services/IApiService.cs
@@ -7,6 +7,7 @@ public interface IApiService
     Task<Dictionary<string, List<Game>>> GetAllGamesAsync(bool forceRefresh = false);
     Task<StreamResponse?> GetStreamsAsync(string league, string homeTeam, string awayTeam, bool forceRefresh = false);
     Task<M3U8Response?> GetM3U8UrlAsync(string streamUrl);
+    Task<M3U8Response?> GetM3U8UrlAsync(string streamUrl, string? playerStreamName);
     
     /// <summary>
     /// Gets enriched streams with incremental m3u8 resolution and metadata

--- a/VardyParty.Core/Services/ILeagueFilterPreferencesStore.cs
+++ b/VardyParty.Core/Services/ILeagueFilterPreferencesStore.cs
@@ -1,0 +1,12 @@
+namespace VardyParty.Services;
+
+public interface ILeagueFilterPreferencesStore
+{
+    bool HasSavedPreferences { get; }
+
+    IReadOnlySet<string> LoadHiddenLeagues();
+
+    void SaveHiddenLeagues(IReadOnlySet<string> hiddenLeagues);
+
+    void ClearSavedPreferences();
+}

--- a/VardyParty.Core/Services/ILeagueFilterService.cs
+++ b/VardyParty.Core/Services/ILeagueFilterService.cs
@@ -1,0 +1,24 @@
+using VardyParty.Models;
+
+namespace VardyParty.Services;
+
+public interface ILeagueFilterService
+{
+    IReadOnlySet<string> DefaultHiddenLeagues { get; }
+
+    IReadOnlySet<string> HiddenLeagues { get; }
+
+    event Action? Changed;
+
+    bool IsLeagueVisible(string? league);
+
+    List<Game> FilterGames(IEnumerable<Game>? games);
+
+    IReadOnlyList<string> GetKnownLeagues(IDictionary<string, List<Game>>? gamesByLeague);
+
+    void SetLeagueVisible(string league, bool visible);
+
+    void SetLeaguesVisible(IEnumerable<string> leagues, bool visible);
+
+    void ResetToDefaults();
+}

--- a/VardyParty.Core/Services/ILocalLanPlayService.cs
+++ b/VardyParty.Core/Services/ILocalLanPlayService.cs
@@ -5,5 +5,16 @@ namespace VardyParty.Services;
 public interface ILocalLanPlayService
 {
     Task<M3U8Response?> ResolveM3U8UrlAsync(string streamUrl, CancellationToken cancellationToken = default);
+
+    Task<M3U8Response?> ResolveM3U8UrlAsync(
+        string streamUrl,
+        string? playerStreamName,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Whether the discovered local service supports <c>/play?stream=</c> (newer builds only).
+    /// </summary>
+    Task<bool> SupportsPlayStreamQueryAsync(CancellationToken cancellationToken = default);
+
     Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default);
 }

--- a/VardyParty.Core/Services/INativeVideoPlayerService.cs
+++ b/VardyParty.Core/Services/INativeVideoPlayerService.cs
@@ -13,7 +13,8 @@ namespace VardyParty.Services
             Func<Task>? onNextStreamRequested = null,
             string? league = null,
             string? homeTeam = null,
-            string? awayTeam = null);
+            string? awayTeam = null,
+            IReadOnlyDictionary<string, string>? requestHeaders = null);
 
         /// <summary>
         /// Get current playback metrics including resolution, framerate, and codec information

--- a/VardyParty.Core/Services/InMemoryLeagueFilterPreferencesStore.cs
+++ b/VardyParty.Core/Services/InMemoryLeagueFilterPreferencesStore.cs
@@ -1,0 +1,23 @@
+namespace VardyParty.Services;
+
+public class InMemoryLeagueFilterPreferencesStore : ILeagueFilterPreferencesStore
+{
+    private HashSet<string>? _hiddenLeagues;
+
+    public bool HasSavedPreferences => _hiddenLeagues != null;
+
+    public IReadOnlySet<string> LoadHiddenLeagues()
+    {
+        return _hiddenLeagues ?? new HashSet<string>(LeagueFilterDefaults.HiddenLeagues, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public void SaveHiddenLeagues(IReadOnlySet<string> hiddenLeagues)
+    {
+        _hiddenLeagues = new HashSet<string>(hiddenLeagues, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public void ClearSavedPreferences()
+    {
+        _hiddenLeagues = null;
+    }
+}

--- a/VardyParty.Core/Services/LeagueFilterDefaults.cs
+++ b/VardyParty.Core/Services/LeagueFilterDefaults.cs
@@ -1,0 +1,9 @@
+namespace VardyParty.Services;
+
+public static class LeagueFilterDefaults
+{
+    public static readonly HashSet<string> HiddenLeagues = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "WWE", "Rugby", "NFL", "NHL", "NBA", "UFC", "Boxing", "Formula 1", "MotoGP", "Tennis", "Cricket", "Golf"
+    };
+}

--- a/VardyParty.Core/Services/LeagueFilterService.cs
+++ b/VardyParty.Core/Services/LeagueFilterService.cs
@@ -1,0 +1,126 @@
+using VardyParty.Models;
+
+namespace VardyParty.Services;
+
+public class LeagueFilterService : ILeagueFilterService
+{
+    private readonly ILeagueFilterPreferencesStore _store;
+    private readonly HashSet<string> _hiddenLeagues;
+
+    public LeagueFilterService(ILeagueFilterPreferencesStore store)
+    {
+        _store = store ?? throw new ArgumentNullException(nameof(store));
+        _hiddenLeagues = _store.HasSavedPreferences
+            ? new HashSet<string>(_store.LoadHiddenLeagues(), StringComparer.OrdinalIgnoreCase)
+            : new HashSet<string>(LeagueFilterDefaults.HiddenLeagues, StringComparer.OrdinalIgnoreCase);
+    }
+
+    public IReadOnlySet<string> DefaultHiddenLeagues => LeagueFilterDefaults.HiddenLeagues;
+
+    public IReadOnlySet<string> HiddenLeagues => _hiddenLeagues;
+
+    public event Action? Changed;
+
+    public bool IsLeagueVisible(string? league)
+    {
+        if (string.IsNullOrWhiteSpace(league))
+        {
+            return true;
+        }
+
+        return !_hiddenLeagues.Contains(league);
+    }
+
+    public List<Game> FilterGames(IEnumerable<Game>? games)
+    {
+        if (games == null)
+        {
+            return new List<Game>();
+        }
+
+        return games.Where(g => IsLeagueVisible(g.League)).ToList();
+    }
+
+    public IReadOnlyList<string> GetKnownLeagues(IDictionary<string, List<Game>>? gamesByLeague)
+    {
+        if (gamesByLeague == null || gamesByLeague.Count == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        return gamesByLeague.Keys
+            .Where(k => !string.IsNullOrWhiteSpace(k))
+            .OrderBy(k => k, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    public void SetLeagueVisible(string league, bool visible)
+    {
+        if (string.IsNullOrWhiteSpace(league))
+        {
+            return;
+        }
+
+        var changed = visible
+            ? _hiddenLeagues.Remove(league)
+            : _hiddenLeagues.Add(league);
+
+        if (!changed)
+        {
+            return;
+        }
+
+        PersistAndNotify();
+    }
+
+    public void SetLeaguesVisible(IEnumerable<string> leagues, bool visible)
+    {
+        if (leagues == null)
+        {
+            return;
+        }
+
+        var changed = false;
+        foreach (var league in leagues)
+        {
+            if (string.IsNullOrWhiteSpace(league))
+            {
+                continue;
+            }
+
+            changed = visible
+                ? _hiddenLeagues.Remove(league) || changed
+                : _hiddenLeagues.Add(league) || changed;
+        }
+
+        if (!changed)
+        {
+            return;
+        }
+
+        PersistAndNotify();
+    }
+
+    public void ResetToDefaults()
+    {
+        _hiddenLeagues.Clear();
+        foreach (var league in LeagueFilterDefaults.HiddenLeagues)
+        {
+            _hiddenLeagues.Add(league);
+        }
+
+        _store.ClearSavedPreferences();
+        Changed?.Invoke();
+    }
+
+    private void PersistAndNotify()
+    {
+        Persist();
+        Changed?.Invoke();
+    }
+
+    private void Persist()
+    {
+        _store.SaveHiddenLeagues(_hiddenLeagues);
+    }
+}

--- a/VardyParty.Core/Services/LocalLanPlayService.cs
+++ b/VardyParty.Core/Services/LocalLanPlayService.cs
@@ -237,7 +237,13 @@ public class LocalLanPlayService(
             var json = await response.Content.ReadAsStringAsync(cts.Token);
             var result = JsonSerializer.Deserialize<M3U8Response>(json,
                 new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-            logger.LogDebug("[LocalLanPlay] Successfully resolved m3u8 via local service");
+            if (result == null || string.IsNullOrWhiteSpace(result.Url))
+            {
+                logger.LogWarning("[LocalLanPlay] Local service returned success but no m3u8 URL in response body");
+                return null;
+            }
+
+            logger.LogInformation("[LocalLanPlay] Resolved m3u8 via local service for {StreamUrl}", streamUrl);
             return result;
         }
         catch (Exception ex)

--- a/VardyParty.Core/Services/LocalLanPlayService.cs
+++ b/VardyParty.Core/Services/LocalLanPlayService.cs
@@ -46,6 +46,17 @@ public class LocalLanPlayService(
 
     private string? _cachedBaseUrl;
     private DateTimeOffset _cachedBaseUrlAt = DateTimeOffset.MinValue;
+    private string[] _cachedCapabilities = [];
+    private DateTimeOffset _capabilitiesCachedAt = DateTimeOffset.MinValue;
+
+    public async Task<bool> SupportsPlayStreamQueryAsync(CancellationToken cancellationToken = default)
+    {
+        await RefreshCapabilitiesIfNeededAsync(cancellationToken);
+        return SupportsPlayStreamQuery(_cachedCapabilities);
+    }
+
+    private static bool SupportsPlayStreamQuery(IEnumerable<string> capabilities) =>
+        capabilities.Any(c => string.Equals(c, "play.stream", StringComparison.OrdinalIgnoreCase));
 
     public async Task<bool> IsAvailableAsync(CancellationToken cancellationToken = default)
     {
@@ -64,7 +75,13 @@ public class LocalLanPlayService(
         return await CheckHealthAsync(baseUrl, cancellationToken);
     }
 
-    public async Task<M3U8Response?> ResolveM3U8UrlAsync(string streamUrl, CancellationToken cancellationToken = default)
+    public Task<M3U8Response?> ResolveM3U8UrlAsync(string streamUrl, CancellationToken cancellationToken = default) =>
+        ResolveM3U8UrlAsync(streamUrl, playerStreamName: null, cancellationToken);
+
+    public async Task<M3U8Response?> ResolveM3U8UrlAsync(
+        string streamUrl,
+        string? playerStreamName,
+        CancellationToken cancellationToken = default)
     {
         if (string.IsNullOrWhiteSpace(streamUrl))
             return null;
@@ -76,7 +93,18 @@ public class LocalLanPlayService(
             return null;
         }
 
-        var resolved = await CallPlayEndpointAsync(baseUrl, streamUrl, cancellationToken);
+        await RefreshCapabilitiesIfNeededAsync(cancellationToken);
+        var effectiveStreamName = SupportsPlayStreamQuery(_cachedCapabilities)
+            ? playerStreamName
+            : null;
+        if (!string.IsNullOrWhiteSpace(playerStreamName) && effectiveStreamName is null)
+        {
+            logger.LogDebug(
+                "[LocalLanPlay] Local service does not advertise play.stream; resolving without stream query param for {Url}",
+                streamUrl);
+        }
+
+        var resolved = await CallPlayEndpointAsync(baseUrl, streamUrl, effectiveStreamName, cancellationToken);
         if (resolved != null)
             return resolved;
 
@@ -85,7 +113,68 @@ public class LocalLanPlayService(
         if (string.IsNullOrWhiteSpace(baseUrl))
             return null;
 
-        return await CallPlayEndpointAsync(baseUrl, streamUrl, cancellationToken);
+        return await CallPlayEndpointAsync(baseUrl, streamUrl, effectiveStreamName, cancellationToken);
+    }
+
+    private async Task RefreshCapabilitiesIfNeededAsync(CancellationToken cancellationToken)
+    {
+        if (_capabilitiesCachedAt != DateTimeOffset.MinValue
+            && DateTimeOffset.UtcNow - _capabilitiesCachedAt < DiscoveryCacheTtl
+            && _cachedCapabilities.Length > 0)
+        {
+            return;
+        }
+
+        var baseUrl = await ResolveServiceBaseUrlAsync(cancellationToken);
+        if (string.IsNullOrWhiteSpace(baseUrl))
+        {
+            _cachedCapabilities = [];
+            _capabilitiesCachedAt = DateTimeOffset.UtcNow;
+            return;
+        }
+
+        _cachedCapabilities = await FetchCapabilitiesFromHealthAsync(baseUrl, cancellationToken);
+        _capabilitiesCachedAt = DateTimeOffset.UtcNow;
+    }
+
+    private async Task<string[]> FetchCapabilitiesFromHealthAsync(string baseUrl, CancellationToken cancellationToken)
+    {
+        var healthUrl = $"{baseUrl.TrimEnd('/')}/health";
+
+        try
+        {
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(3));
+            var response = await httpClient.GetAsync(healthUrl, cts.Token);
+            if (!response.IsSuccessStatusCode)
+            {
+                return [];
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cts.Token);
+            using var doc = JsonDocument.Parse(json);
+            return ParseCapabilities(doc.RootElement);
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex, "[LocalLanPlay] Failed to read capabilities from {Url}", healthUrl);
+            return [];
+        }
+    }
+
+    private static string[] ParseCapabilities(JsonElement root)
+    {
+        if (!root.TryGetProperty("capabilities", out var capabilitiesElement)
+            || capabilitiesElement.ValueKind != JsonValueKind.Array)
+        {
+            return [];
+        }
+
+        return capabilitiesElement.EnumerateArray()
+            .Select(element => element.GetString())
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!)
+            .ToArray();
     }
 
     private async Task<bool> CheckHealthAsync(string baseUrl, CancellationToken cancellationToken)
@@ -107,6 +196,10 @@ public class LocalLanPlayService(
             else
             {
                 logger.LogDebug("[LocalLanPlay] Health check successful for {Url}", healthUrl);
+                var json = await response.Content.ReadAsStringAsync(cts.Token);
+                using var doc = JsonDocument.Parse(json);
+                _cachedCapabilities = ParseCapabilities(doc.RootElement);
+                _capabilitiesCachedAt = DateTimeOffset.UtcNow;
             }
 
             return isOk;
@@ -120,9 +213,17 @@ public class LocalLanPlayService(
         }
     }
 
-    private async Task<M3U8Response?> CallPlayEndpointAsync(string baseUrl, string streamUrl, CancellationToken cancellationToken)
+    private async Task<M3U8Response?> CallPlayEndpointAsync(
+        string baseUrl,
+        string streamUrl,
+        string? playerStreamName,
+        CancellationToken cancellationToken)
     {
         var url = $"{baseUrl.TrimEnd('/')}/play/{Uri.EscapeDataString(streamUrl)}";
+        if (!string.IsNullOrWhiteSpace(playerStreamName))
+        {
+            url += $"?stream={Uri.EscapeDataString(playerStreamName.Trim())}";
+        }
 
         try
         {
@@ -242,6 +343,8 @@ public class LocalLanPlayService(
 
                 var host = received.RemoteEndPoint.Address.ToString();
                 var discoveredUrl = $"http://{host}:{httpPort}";
+                _cachedCapabilities = ParseCapabilities(root);
+                _capabilitiesCachedAt = DateTimeOffset.UtcNow;
                 logger.LogInformation("[LocalLanPlay] Successfully discovered local service endpoint: {Endpoint}", discoveredUrl);
                 return discoveredUrl;
             }
@@ -262,5 +365,7 @@ public class LocalLanPlayService(
     {
         _cachedBaseUrl = null;
         _cachedBaseUrlAt = DateTimeOffset.MinValue;
+        _cachedCapabilities = [];
+        _capabilitiesCachedAt = DateTimeOffset.MinValue;
     }
 }

--- a/VardyParty.Core/VardyPartyClientApiVersion.cs
+++ b/VardyParty.Core/VardyPartyClientApiVersion.cs
@@ -1,0 +1,14 @@
+namespace VardyParty;
+
+/// <summary>
+/// API version negotiation via <c>X-VardyParty-Client-Api-Version</c>.
+/// </summary>
+public static class VardyPartyClientApiVersion
+{
+    public const string HeaderName = "X-VardyParty-Client-Api-Version";
+
+    public const int Legacy = 1;
+    public const int V2StreamMetadata = 2;
+
+    public const string DefaultHeaderValue = "2";
+}

--- a/VardyParty.Linux/App.axaml.cs
+++ b/VardyParty.Linux/App.axaml.cs
@@ -72,12 +72,14 @@ public class App : Application
             .AddJsonFile(appSettingsFileName, false, true)
             .Build()
             .GetSection("Api");
+        // Default to production; set VARDYPARTY_DEBUG_API=local|preview to override.
         var debugApiTarget = Environment.GetEnvironmentVariable("VARDYPARTY_DEBUG_API");
         var debugBaseUrl = debugApiTarget?.Trim().ToLowerInvariant() switch
         {
+            "local" => apiConfig["HeadlessBaseUrl-Local"],
             "preview" => apiConfig["HeadlessBaseUrl-Preview"],
             "production" or "prod" => apiConfig["HeadlessBaseUrl"],
-            _ => apiConfig["HeadlessBaseUrl-Local"],
+            _ => apiConfig["HeadlessBaseUrl"],
         };
         if (!string.IsNullOrWhiteSpace(debugBaseUrl))
         {
@@ -85,7 +87,7 @@ public class App : Application
             {
                 ["Api:HeadlessBaseUrl"] = debugBaseUrl
             });
-            Console.WriteLine($"[App] DEBUG: Using API at {debugBaseUrl} (target={debugApiTarget ?? "local"})");
+            Console.WriteLine($"[App] DEBUG: Using API at {debugBaseUrl} (target={debugApiTarget ?? "production"})");
         }
 #endif
 

--- a/VardyParty.Linux/App.axaml.cs
+++ b/VardyParty.Linux/App.axaml.cs
@@ -7,6 +7,7 @@ using LibVLCSharp.Shared;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using VardyParty;
 using VardyParty.Configuration;
 using VardyParty.Handlers;
 using VardyParty.Health;
@@ -65,6 +66,22 @@ public class App : Application
             configurationBuilder.AddJsonFile(userSecretsPath, true, true);
         }
 
+#if DEBUG
+        var previewBaseUrl = new ConfigurationBuilder()
+            .SetBasePath(appSettingsDirectory)
+            .AddJsonFile(appSettingsFileName, false, true)
+            .Build()
+            .GetSection("Api")["HeadlessBaseUrl-Preview"];
+        if (!string.IsNullOrWhiteSpace(previewBaseUrl))
+        {
+            configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Api:HeadlessBaseUrl"] = previewBaseUrl
+            });
+            Console.WriteLine($"[App] DEBUG: Using preview API at {previewBaseUrl}");
+        }
+#endif
+
         var configuration = configurationBuilder.Build();
 
         var services = new ServiceCollection();
@@ -114,7 +131,13 @@ public class App : Application
         services.AddHttpClient<IStreamHealthService, StreamHealthService>()
             .AddHttpMessageHandler<Auth0ApiTokenHandler>();
         services.AddHttpClient<IApiService, ApiService>()
-            .AddHttpMessageHandler<Auth0ApiTokenHandler>();
+            .AddHttpMessageHandler<Auth0ApiTokenHandler>()
+            .ConfigureHttpClient(client =>
+            {
+                client.DefaultRequestHeaders.TryAddWithoutValidation(
+                    VardyPartyClientApiVersion.HeaderName,
+                    VardyPartyClientApiVersion.DefaultHeaderValue);
+            });
 
         services.AddHttpClient<IStreamHealthChecker, StreamHealthChecker>()
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler

--- a/VardyParty.Linux/App.axaml.cs
+++ b/VardyParty.Linux/App.axaml.cs
@@ -67,18 +67,25 @@ public class App : Application
         }
 
 #if DEBUG
-        var previewBaseUrl = new ConfigurationBuilder()
+        var apiConfig = new ConfigurationBuilder()
             .SetBasePath(appSettingsDirectory)
             .AddJsonFile(appSettingsFileName, false, true)
             .Build()
-            .GetSection("Api")["HeadlessBaseUrl-Preview"];
-        if (!string.IsNullOrWhiteSpace(previewBaseUrl))
+            .GetSection("Api");
+        var debugApiTarget = Environment.GetEnvironmentVariable("VARDYPARTY_DEBUG_API");
+        var debugBaseUrl = debugApiTarget?.Trim().ToLowerInvariant() switch
+        {
+            "preview" => apiConfig["HeadlessBaseUrl-Preview"],
+            "production" or "prod" => apiConfig["HeadlessBaseUrl"],
+            _ => apiConfig["HeadlessBaseUrl-Local"],
+        };
+        if (!string.IsNullOrWhiteSpace(debugBaseUrl))
         {
             configurationBuilder.AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Api:HeadlessBaseUrl"] = previewBaseUrl
+                ["Api:HeadlessBaseUrl"] = debugBaseUrl
             });
-            Console.WriteLine($"[App] DEBUG: Using preview API at {previewBaseUrl}");
+            Console.WriteLine($"[App] DEBUG: Using API at {debugBaseUrl} (target={debugApiTarget ?? "local"})");
         }
 #endif
 
@@ -110,6 +117,8 @@ public class App : Application
         services.AddSingleton<IBbcHtmlParser, BbcHtmlParser>();
         services.AddSingleton<IStreamDeduplicator, StreamDeduplicator>();
         services.AddSingleton<IEnrichedGameService, EnrichedGameService>();
+        services.AddSingleton<ILeagueFilterPreferencesStore, InMemoryLeagueFilterPreferencesStore>();
+        services.AddSingleton<ILeagueFilterService, LeagueFilterService>();
         services.AddSingleton<IHomePagePresentationService, HomePagePresentationService>();
         services.AddSingleton<IStreamSwitchingService, StreamSwitchingService>();
         services.AddSingleton<IStreamSelectionCoordinator, StreamSelectionCoordinator>();

--- a/VardyParty.Linux/MainWindowViewModel.cs
+++ b/VardyParty.Linux/MainWindowViewModel.cs
@@ -35,6 +35,7 @@ public class MainWindowViewModel : INotifyPropertyChanged, IDisposable
     private readonly IAuthLoginService _authLoginService;
     private readonly IAuthTokenProvider _authTokenProvider;
     private readonly IEnrichedGameService _enrichedGameService;
+    private readonly ILeagueFilterService _leagueFilter;
     private readonly IStreamResolutionOrchestrator _streamResolutionOrchestrator;
     private readonly SelectionState _selectionState;
     private readonly IServiceProvider _serviceProvider;
@@ -61,6 +62,7 @@ public class MainWindowViewModel : INotifyPropertyChanged, IDisposable
         IAuthLoginService authLoginService,
         IAuthTokenProvider authTokenProvider,
         IEnrichedGameService enrichedGameService,
+        ILeagueFilterService leagueFilter,
         IStreamResolutionOrchestrator streamResolutionOrchestrator,
         SelectionState selectionState,
         IServiceProvider serviceProvider,
@@ -70,6 +72,7 @@ public class MainWindowViewModel : INotifyPropertyChanged, IDisposable
         _authLoginService = authLoginService;
         _authTokenProvider = authTokenProvider;
         _enrichedGameService = enrichedGameService;
+        _leagueFilter = leagueFilter;
         _streamResolutionOrchestrator = streamResolutionOrchestrator;
         _selectionState = selectionState;
         _serviceProvider = serviceProvider;
@@ -103,7 +106,7 @@ public class MainWindowViewModel : INotifyPropertyChanged, IDisposable
                 return;
             }
 
-            var displayGames = dict.ToDisplay();
+            var displayGames = _leagueFilter.FilterGames(dict.ToDisplay());
             _ = Task.Run(async () =>
             {
                 var items = await BuildDisplayGamesAsync(displayGames);
@@ -279,7 +282,7 @@ public class MainWindowViewModel : INotifyPropertyChanged, IDisposable
 
             var apiService = _serviceProvider.GetRequiredService<IApiService>();
             var gamesByLeague = await apiService.GetAllGamesAsync(true);
-            var items = await BuildDisplayGamesAsync(gamesByLeague.ToDisplay());
+            var items = await BuildDisplayGamesAsync(_leagueFilter.FilterGames(gamesByLeague.ToDisplay()));
             ApplyDisplayGames(items);
             StatusMessage = $"Loaded {Games.Count} games";
         }

--- a/VardyParty.Linux/Services/LinuxVideoPlayerService.cs
+++ b/VardyParty.Linux/Services/LinuxVideoPlayerService.cs
@@ -101,7 +101,8 @@ public class LinuxVideoPlayerService : INativeVideoPlayerService, IDisposable
         Func<Task>? onNextStreamRequested = null,
         string? league = null,
         string? homeTeam = null,
-        string? awayTeam = null)
+        string? awayTeam = null,
+        IReadOnlyDictionary<string, string>? requestHeaders = null)
     {
         _logger.LogInformation("[LinuxVideoPlayerService] Playing video: {Title}", title);
         _logger.LogInformation("[LinuxVideoPlayerService] URL: {Url}", m3u8Url);

--- a/VardyParty/Components/Pages/GameCard.razor
+++ b/VardyParty/Components/Pages/GameCard.razor
@@ -123,7 +123,7 @@
 
     private async Task OnCardKeyDown(KeyboardEventArgs e)
     {
-        if (e.Key is "Enter" or " " or "Spacebar")
+        if (e.Key is "Enter" or " " or "Spacebar" or "NumpadEnter")
         {
             await OnCardClick();
         }

--- a/VardyParty/Components/Pages/GameCard.razor
+++ b/VardyParty/Components/Pages/GameCard.razor
@@ -1,8 +1,15 @@
 @using VardyParty.Models
 @using VardyParty.Services
 @using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Web
 
-<div class="@CardClass" tabindex="0" @onclick="OnCardClick" @ref="cardRef">
+<div class="@CardClass"
+     tabindex="0"
+     role="button"
+     aria-pressed="@IsSelected"
+     @onclick="OnCardClick"
+     @onkeydown="OnCardKeyDown"
+     @ref="cardRef">
     <div class="league-badge@(string.IsNullOrEmpty(LeagueLogoUrl) ? " league-badge-empty" : string.Empty)">
         @if (!string.IsNullOrEmpty(LeagueLogoUrl))
         {
@@ -111,6 +118,14 @@
         if (OnClick.HasDelegate)
         {
             await OnClick.InvokeAsync(Game);
+        }
+    }
+
+    private async Task OnCardKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar")
+        {
+            await OnCardClick();
         }
     }
 

--- a/VardyParty/Components/Pages/GameCard.razor.css
+++ b/VardyParty/Components/Pages/GameCard.razor.css
@@ -36,12 +36,14 @@
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
 }
 
+.game-card:focus,
 .game-card:focus-visible {
     border-color: var(--primary-blue);
     box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.45), 0 8px 24px rgba(0, 0, 0, 0.22);
     transform: translateY(-1px);
 }
 
+.game-card:focus::before,
 .game-card:focus-visible::before {
     opacity: 1;
 }

--- a/VardyParty/Components/Pages/GameCard.razor.css
+++ b/VardyParty/Components/Pages/GameCard.razor.css
@@ -9,18 +9,47 @@
     row-gap: 4px;
     padding: 15px 20px;
     border: 2px solid var(--border-color);
-    border-radius: 12px;
-    background: var(--bg-card);
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.01)), var(--bg-card);
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease, background 0.2s ease;
     position: relative;
     overflow: hidden;
     min-height: 80px;
+    outline: none;
+}
+
+.game-card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.2s ease;
+    box-shadow: inset 0 0 0 1px rgba(74, 158, 255, 0.35);
+}
+
+.game-card:hover {
+    border-color: rgba(255, 255, 255, 0.22);
+    transform: translateY(-1px);
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.22);
+}
+
+.game-card:focus-visible {
+    border-color: var(--primary-blue);
+    box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.45), 0 8px 24px rgba(0, 0, 0, 0.22);
+    transform: translateY(-1px);
+}
+
+.game-card:focus-visible::before {
+    opacity: 1;
 }
 
 .game-card.selected {
-    border-color: rgba(255, 255, 255, 0.85);
-    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.15);
+    border-color: rgba(74, 158, 255, 0.75);
+    background: linear-gradient(135deg, rgba(74, 158, 255, 0.12), rgba(74, 158, 255, 0.04)), var(--bg-card);
+    box-shadow: 0 8px 20px rgba(74, 158, 255, 0.15);
 }
 
 .league-badge {
@@ -70,6 +99,20 @@
     align-items: center;
     justify-content: flex-start;
     gap: 5px;
+}
+
+.live-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #ff4444;
+    box-shadow: 0 0 8px rgba(255, 68, 68, 0.6);
+    animation: live-pulse 1.4s ease-in-out infinite;
+}
+
+@keyframes live-pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.65; transform: scale(0.85); }
 }
 
 .status-upcoming {

--- a/VardyParty/Components/Pages/Home.razor
+++ b/VardyParty/Components/Pages/Home.razor
@@ -17,7 +17,7 @@
 @using VardyParty.Services
 @implements IDisposable
 
-<div class="page-shell@(OperatingSystem.IsWindows() ? " platform-windows" : OperatingSystem.IsAndroid() ? " platform-android" : string.Empty)">
+<div class="page-shell@(GetPlatformShellClass())">
     <header class="page-header">
         <div class="page-header-inner">
             <div class="header-left">
@@ -42,34 +42,50 @@
 
     @if (!isAuthenticated)
     {
-        <div class="auth-hero">
-            <div class="auth-hero-inner">
-                <div class="state-icon state-icon-auth" aria-hidden="true">🔐</div>
-                <p class="welcome-text">Welcome — please sign in to browse today's matches.</p>
-                <div class="auth-actions">
-                    <button class="btn btn-primary auth-action" @onclick="StartSignInAsync" disabled="@isAuthenticating">@(!isAuthenticating ? "Sign in — Continue" : "Signing in…")</button>
-                </div>
-                @if (!string.IsNullOrWhiteSpace(authStatusMessage))
-                {
-                    <div class="auth-message">@authStatusMessage</div>
-                }
-            </div>
-
+        <div class="auth-hero@(deviceCode != null ? " auth-hero-device" : string.Empty)">
             @if (deviceCode != null)
             {
                 <div class="auth-device">
-                    <div>
-                        @if (!string.IsNullOrWhiteSpace(deviceQrDataUri))
+                    <div class="auth-device-copy">
+                        <p class="auth-device-code">Code <strong>@deviceCode.UserCode</strong></p>
+                        <button @ref="authCancelButtonRef"
+                                type="button"
+                                class="auth-cancel"
+                                tabindex="0"
+                                autofocus="true"
+                                @onclick="CancelSignIn"
+                                @onkeydown="OnAuthCancelKeyDown">Cancel</button>
+                        @if (!string.IsNullOrWhiteSpace(authStatusMessage))
                         {
-                            <img src="@deviceQrDataUri" alt="Device login QR code" class="qr-image"/>
+                            <div class="auth-message">@authStatusMessage</div>
                         }
                     </div>
-                    <div>
-                        <p>Open <strong>@deviceQrTarget</strong> or scan the QR code and enter code <strong>@deviceCode.UserCode</strong>.</p>
-                        <p style="margin-top:12px;">
-                            <button class="auth-cancel" @onclick="CancelSignIn">Cancel</button>
-                        </p>
+                    @if (!string.IsNullOrWhiteSpace(deviceQrDataUri))
+                    {
+                        <img src="@deviceQrDataUri" alt="Device login QR code" class="qr-image"/>
+                    }
+                    <p class="auth-device-uri">Scan the QR code, or open <strong>@deviceQrTarget</strong></p>
+                </div>
+            }
+            else
+            {
+                <div class="auth-hero-inner">
+                    <div class="state-icon state-icon-auth" aria-hidden="true">🔐</div>
+                    <p class="welcome-text">Welcome — please sign in to browse today's matches.</p>
+                    <div class="auth-actions">
+                        <button @ref="signInContinueButtonRef"
+                                type="button"
+                                class="btn btn-primary auth-action"
+                                tabindex="0"
+                                autofocus="@(!isAuthenticating)"
+                                @onclick="StartSignInAsync"
+                                @onkeydown="OnSignInContinueKeyDown"
+                                disabled="@isAuthenticating">@(!isAuthenticating ? "Sign in — Continue" : "Signing in…")</button>
                     </div>
+                    @if (!string.IsNullOrWhiteSpace(authStatusMessage))
+                    {
+                        <div class="auth-message">@authStatusMessage</div>
+                    }
                 </div>
             }
         </div>
@@ -119,7 +135,11 @@
             {
                 var game = games[i];
                 var isSelected = IsSelected(game);
-                var shouldFocus = !skipGameCardAutofocus && focusPending && (isSelected || (!anySelected && i == 0));
+                // TV: do not autofocus games[0] — that leaves a permanent focus ring.
+                // Selection is also skipped on TV until OK (EnsureInitialSelection).
+                var shouldFocus = !MauiProgram.IsTv
+                    && focusPending
+                    && (isSelected || (!anySelected && i == 0));
                 var leagueLogo = LeagueLogoMapper.GetLogoForLeague(game);
 
                 <GameCard Game="game"
@@ -211,7 +231,21 @@
     private readonly List<Game> games = new();
     private bool isLoading = true;
     private bool focusPending = true;
-    private static readonly bool skipGameCardAutofocus = MauiProgram.IsTv;
+    private bool signInContinueFocusPending = true;
+    private bool authCancelFocusPending;
+    private ElementReference signInContinueButtonRef;
+    private ElementReference authCancelButtonRef;
+
+    private static string GetPlatformShellClass()
+    {
+        if (OperatingSystem.IsWindows()) return " platform-windows";
+        if (OperatingSystem.IsAndroid())
+        {
+            return MauiProgram.IsTv ? " platform-android platform-android-tv" : " platform-android";
+        }
+
+        return string.Empty;
+    }
     private IDisposable? _gamesSubscription;
     private IDisposable? _errorSubscription;
     private IDisposable? _localLanWarningSubscription;
@@ -319,6 +353,14 @@
             return;
         }
 
+        // Device QR screen: Back cancels sign-in (same as Cancel).
+        if (!isAuthenticated && deviceCode != null)
+        {
+            Logger.LogInformation("[Home] Android back pressed during device sign-in — canceling");
+            CancelSignIn();
+            return;
+        }
+
         Logger.LogInformation("[Home] Android back pressed - canceling stream resolution if active");
         try
         {
@@ -378,6 +420,7 @@
     {
         if (isAuthenticating) return;
 
+        Logger.LogInformation("[Home] Sign in — Continue pressed (IsTv={IsTv})", MauiProgram.IsTv);
         isAuthenticating = true;
         authStatusMessage = string.Empty;
         deviceCode = null;
@@ -395,6 +438,7 @@
                 }
 
                 deviceCode = deviceLogin.DeviceCode;
+                authCancelFocusPending = true;
 
                 // Generate local QR for device flow
                 deviceQrTarget = string.IsNullOrWhiteSpace(deviceCode.VerificationUriComplete) ? deviceCode.VerificationUri : deviceCode.VerificationUriComplete;
@@ -418,11 +462,12 @@
                 _authCts = new CancellationTokenSource();
 
                 var result = await AuthLoginService.PollDeviceLoginAsync(deviceLogin.DeviceCode, _authCts.Token);
-                if (result.IsSuccess && !string.IsNullOrWhiteSpace(result.AccessToken))
+        if (result.IsSuccess && !string.IsNullOrWhiteSpace(result.AccessToken))
                 {
                     isAuthenticated = true;
                     authStatusMessage = string.Empty;
                     deviceCode = null;
+                    focusPending = true;
                     await LoadGamesAsync();
                 }
                 else if (!string.IsNullOrWhiteSpace(result.Error))
@@ -437,6 +482,7 @@
                 {
                     isAuthenticated = true;
                     authStatusMessage = string.Empty;
+                    focusPending = true;
                     await LoadGamesAsync();
                 }
                 else if (!string.IsNullOrWhiteSpace(result.Error))
@@ -451,17 +497,55 @@
         }
         catch (Exception ex)
         {
-            authStatusMessage = ex.Message;
+            Logger.LogWarning(ex, "[Home] Sign-in failed");
+            authStatusMessage = string.IsNullOrWhiteSpace(ex.Message)
+                ? "Sign-in failed."
+                : ex.Message;
         }
         finally
         {
             isAuthenticating = false;
+            if (!isAuthenticated)
+            {
+                signInContinueFocusPending = true;
+            }
             await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task OnSignInContinueKeyDown(KeyboardEventArgs e)
+    {
+        // Android TV remotes often send Enter/DPAD_CENTER without a click event.
+        if (e.Key is "Enter" or " " or "Spacebar" or "NumpadEnter")
+        {
+            await StartSignInAsync();
+        }
+    }
+
+    private void OnAuthCancelKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar" or "NumpadEnter")
+        {
+            CancelSignIn();
         }
     }
 
     private async Task SignOutAsync()
     {
+        try
+        {
+            _authCts?.Cancel();
+        }
+        catch
+        {
+        }
+
+        _authCts = null;
+        isAuthenticating = false;
+        deviceCode = null;
+        deviceQrDataUri = null;
+        deviceQrTarget = null;
+
         await AuthTokenProvider.LogoutAsync();
 
         _gamesSubscription?.Dispose();
@@ -475,11 +559,14 @@
         StreamResolutionOrchestrator.Reset();
 
         games.Clear();
+        Selection.CurrentGame = null;
+        selectedGame = null;
         statusMessage = string.Empty;
         authStatusMessage = string.Empty;
         isAuthenticated = false;
         isLoading = false;
-        deviceCode = null;
+        focusPending = true;
+        signInContinueFocusPending = true;
         await InvokeAsync(StateHasChanged);
     }
 
@@ -491,6 +578,7 @@
         deviceQrTarget = null;
         isAuthenticating = false;
         authStatusMessage = "Sign-in canceled.";
+        signInContinueFocusPending = true;
     }
 
     private void OnOverlayCloseRequested()
@@ -532,11 +620,41 @@
         InvokeAsync(StateHasChanged);
     }
 
-    protected override Task OnAfterRenderAsync(bool firstRender)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (focusPending && isAuthenticated && games.Count > 0)
         {
             focusPending = false;
+        }
+
+        // Android TV / D-pad: put focus on Sign in — Continue when that CTA is visible.
+        // Without this, the header menu button typically owns first focus.
+        if (signInContinueFocusPending
+            && !isAuthenticated
+            && !isAuthenticating
+            && deviceCode == null)
+        {
+            try
+            {
+                await signInContinueButtonRef.FocusAsync();
+                signInContinueFocusPending = false;
+            }
+            catch
+            {
+                // Element may not be ready yet; retry on next render.
+            }
+        }
+
+        if (authCancelFocusPending && !isAuthenticated && deviceCode != null)
+        {
+            try
+            {
+                await authCancelButtonRef.FocusAsync();
+                authCancelFocusPending = false;
+            }
+            catch
+            {
+            }
         }
 
         // If user returned from native player (selectedGame still set) restart stream resolution
@@ -569,8 +687,6 @@
         catch
         {
         }
-
-        return Task.CompletedTask;
     }
 
     private void OnGamesUpdated(Dictionary<string, List<Game>>? updatedGames)
@@ -623,6 +739,13 @@
         if (games.Count == 0)
         {
             Selection.CurrentGame = null;
+            return;
+        }
+
+        // On TV, D-pad focus is the navigation cue. Auto-selecting games[0] leaves a second
+        // "selected" highlight that doesn't move with the remote.
+        if (MauiProgram.IsTv)
+        {
             return;
         }
 

--- a/VardyParty/Components/Pages/Home.razor
+++ b/VardyParty/Components/Pages/Home.razor
@@ -8,7 +8,7 @@
 @inject IAuthLoginService AuthLoginService
 @inject IAuthTokenProvider AuthTokenProvider
 @inject ILocalLanServiceAvailabilityMonitor LocalLanServiceAvailabilityMonitor
-@inject IBuildInfoService BuildInfoService
+@inject ILeagueFilterService LeagueFilter
 @using Microsoft.Extensions.Logging
 @using QRCoder
 @using VardyParty.Models
@@ -20,19 +20,12 @@
 <div class="page-shell@(OperatingSystem.IsWindows() ? " platform-windows" : OperatingSystem.IsAndroid() ? " platform-android" : string.Empty)">
     <header class="page-header">
         <div class="page-header-inner">
-            @if (buildInfo is not null)
-            {
-                <div class="header-build-info" title="Commit @buildInfo.Commit · @buildInfo.BuiltAtFull">v@(buildInfo.Version) · @buildInfo.BuiltAt</div>
-            }
-            <div class="header-brand">
-                <img src="images/vardyparty_splash.svg" class="app-logo" alt="VardyParty Logo" style="display:inline-block;vertical-align:middle;"/>
-                <div class="header-title" role="heading" aria-level="1" style="display:inline-block;vertical-align:middle;margin-left:8px;">Vardy Party</div>
+            <div class="header-left">
+                <AppMenu IsAuthenticated="isAuthenticated" OnSignOut="SignOutAsync" />
             </div>
-            <div class="header-right">
-                @if (isAuthenticated)
-                {
-                    <button class="header-auth-button" @onclick="SignOutAsync">Sign out</button>
-                }
+            <div class="header-brand">
+                <img src="images/vardyparty_splash.svg" class="app-logo" alt="VardyParty Logo" />
+                <div class="header-title" role="heading" aria-level="1">Vardy Party</div>
             </div>
         </div>
     </header>
@@ -42,18 +35,23 @@
     {
         <div class="local-service-warning">@localServiceWarning</div>
     }
+    @if (!string.IsNullOrWhiteSpace(statusMessage) && isAuthenticated && games.Count > 0)
+    {
+        <div class="local-service-warning">@statusMessage</div>
+    }
 
     @if (!isAuthenticated)
     {
         <div class="auth-hero">
             <div class="auth-hero-inner">
-                <p class="welcome-text" style="margin:0;font-size:20px;font-weight:600;text-align:center;">Welcome — please sign in to browse today's matches.</p>
-                <div style="display:flex;gap:12px;align-items:center;justify-content:center;">
+                <div class="state-icon state-icon-auth" aria-hidden="true">🔐</div>
+                <p class="welcome-text">Welcome — please sign in to browse today's matches.</p>
+                <div class="auth-actions">
                     <button class="btn btn-primary auth-action" @onclick="StartSignInAsync" disabled="@isAuthenticating">@(!isAuthenticating ? "Sign in — Continue" : "Signing in…")</button>
                 </div>
                 @if (!string.IsNullOrWhiteSpace(authStatusMessage))
                 {
-                    <div class="auth-message" style="text-align:center;margin-top:8px;">@authStatusMessage</div>
+                    <div class="auth-message">@authStatusMessage</div>
                 }
             </div>
 
@@ -68,7 +66,7 @@
                     </div>
                     <div>
                         <p>Open <strong>@deviceQrTarget</strong> or scan the QR code and enter code <strong>@deviceCode.UserCode</strong>.</p>
-                        <p style="margin-top:8px;">
+                        <p style="margin-top:12px;">
                             <button class="auth-cancel" @onclick="CancelSignIn">Cancel</button>
                         </p>
                     </div>
@@ -80,7 +78,8 @@
     @if (isLoading && isAuthenticated)
     {
         <div class="loading-container">
-            <p class="loading-text">Loading</p>
+            <div class="state-icon state-icon-loading" aria-hidden="true"></div>
+            <p class="loading-text">Loading matches</p>
             @if (!string.IsNullOrEmpty(statusMessage))
             {
                 <p class="status-message">@statusMessage</p>
@@ -89,14 +88,16 @@
     }
     else if (!isAuthenticated)
     {
-        <div class="empty-state">
+        <div class="empty-state empty-state-muted">
             <!-- consolidated; hero handles welcome -->
         </div>
     }
     else if (games.Count == 0)
     {
         <div class="empty-state">
-            <p>There are no games available</p>
+            <div class="state-icon state-icon-empty" aria-hidden="true">⚽</div>
+            <h2 class="empty-state-title">No matches right now</h2>
+            <p class="empty-state-text">Check back later — today's schedule will appear here when games are available.</p>
             @if (!string.IsNullOrEmpty(statusMessage))
             {
                 <p class="status-message">@statusMessage</p>
@@ -105,7 +106,12 @@
     }
     else
     {
-        <div class="games-grid">
+        <div class="schedule-section">
+            <div class="schedule-header">
+                <h2 class="schedule-title">Today's matches</h2>
+                <span class="schedule-count">@games.Count @(games.Count == 1 ? "game" : "games")</span>
+            </div>
+            <div class="games-grid">
             @{
                 var anySelected = games.Any(IsSelected);
             }
@@ -113,7 +119,7 @@
             {
                 var game = games[i];
                 var isSelected = IsSelected(game);
-                var shouldFocus = focusPending && (isSelected || (!anySelected && i == 0));
+                var shouldFocus = !skipGameCardAutofocus && focusPending && (isSelected || (!anySelected && i == 0));
                 var leagueLogo = LeagueLogoMapper.GetLogoForLeague(game);
 
                 <GameCard Game="game"
@@ -122,6 +128,7 @@
                           LeagueLogoUrl="@leagueLogo"
                           OnClick="StartStreamResolution"/>
             }
+            </div>
         </div>
     }
 
@@ -204,6 +211,7 @@
     private readonly List<Game> games = new();
     private bool isLoading = true;
     private bool focusPending = true;
+    private static readonly bool skipGameCardAutofocus = MauiProgram.IsTv;
     private IDisposable? _gamesSubscription;
     private IDisposable? _errorSubscription;
     private IDisposable? _localLanWarningSubscription;
@@ -217,13 +225,6 @@
     private string? deviceQrDataUri;
     private string? deviceQrTarget;
     private string? localServiceWarning;
-    private BuildInfo? buildInfo;
-
-    private readonly HashSet<string> _ignoredLeagues = new(StringComparer.OrdinalIgnoreCase)
-    {
-        "WWE", "Rugby", "NFL", "NHL", "NBA", "UFC", "Boxing", "Formula 1", "MotoGP", "Tennis", "Cricket", "Golf"
-    };
-
     private string statusMessage = string.Empty;
 
     // Stream resolution state
@@ -264,7 +265,6 @@
     protected override async Task OnInitializedAsync()
     {
         Logger.LogInformation("[Home] OnInitialized start");
-        buildInfo = await BuildInfoService.GetAsync();
         isLoading = true;
         isAuthenticated = await AuthTokenProvider.IsAuthenticatedAsync();
 
@@ -278,6 +278,7 @@
         }
 
         Logger.LogInformation("[Home] OnInitialized complete");
+        ApplyPlaybackErrorFromQuery();
         if (OperatingSystem.IsWindows())
         {
             try
@@ -313,6 +314,11 @@
 #if ANDROID
     private void AndroidBackHandler(global::Android.Views.Keycode kc)
     {
+        if (MainActivity.IsFlyoutMenuOpen)
+        {
+            return;
+        }
+
         Logger.LogInformation("[Home] Android back pressed - canceling stream resolution if active");
         try
         {
@@ -582,11 +588,8 @@
 
         foreach (var kvp in updatedGames)
         {
-            var league = kvp.Key;
-            if (_ignoredLeagues.Contains(league)) continue;
-
             var leagueGames = kvp.Value ?? new List<Game>();
-            games.AddRange(leagueGames);
+            games.AddRange(LeagueFilter.FilterGames(leagueGames));
         }
 
         EnsureInitialSelection();
@@ -607,7 +610,7 @@
         Logger.LogInformation("[Home] Games updated (flattened): {Count} games", updatedGames.Count);
 
         games.Clear();
-        games.AddRange(updatedGames.Where(g => !_ignoredLeagues.Contains(g.League))); // still filter ignored leagues if present
+        games.AddRange(LeagueFilter.FilterGames(updatedGames));
 
         EnsureInitialSelection();
         isLoading = false;
@@ -740,9 +743,18 @@
                     return;
                 }
 
-                if (outcome.PlaybackResult != null && !outcome.PlaybackResult.Success)
+                if (outcome.NoWorkingStreams)
                 {
-                    await InvokeAsync(() => { NavigateToStreamsWithError(outcome.PlaybackResult.Message); });
+                    await InvokeAsync(() => ShowStreamPlaybackError("No working streams found"));
+                }
+                else if (outcome.PlaybackResult != null && !outcome.PlaybackResult.Success && !outcome.UserClosed)
+                {
+#if WINDOWS
+                    if (!MainPage.IsNativePlayerActive)
+#endif
+                    {
+                        await InvokeAsync(() => ShowStreamPlaybackError(outcome.PlaybackResult.Message));
+                    }
                 }
             }
             catch (OperationCanceledException)
@@ -770,32 +782,49 @@
         });
     }
 
-    private void NavigateToStreamsWithError(string? message)
+    private void ShowStreamPlaybackError(string? message)
     {
-        var league = string.IsNullOrWhiteSpace(Selection.LastLeague)
-            ? Selection.CurrentGame?.ApiLeague ?? selectedGame?.ApiLeague ?? string.Empty
-            : Selection.LastLeague;
-        var home = string.IsNullOrWhiteSpace(Selection.LastHomeTeam)
-            ? Selection.CurrentGame?.Home ?? selectedGame?.Home ?? string.Empty
-            : Selection.LastHomeTeam;
-        var away = string.IsNullOrWhiteSpace(Selection.LastAwayTeam)
-            ? Selection.CurrentGame?.Away ?? selectedGame?.Away ?? string.Empty
-            : Selection.LastAwayTeam;
+        statusMessage = message ?? "Stream unavailable";
+        streamResolutionStatus = statusMessage;
+        isResolvingStreams = false;
+        SetOverlayBackSuppression(false);
+        StateHasChanged();
+    }
 
-        if (string.IsNullOrWhiteSpace(league) || string.IsNullOrWhiteSpace(home) || string.IsNullOrWhiteSpace(away))
+    private void ApplyPlaybackErrorFromQuery()
+    {
+        var query = Navigation.ToAbsoluteUri(Navigation.Uri).Query;
+        if (string.IsNullOrEmpty(query))
         {
-            statusMessage = message ?? "Stream unavailable";
-            StateHasChanged();
             return;
         }
 
-        var encodedLeague = Uri.EscapeDataString(league);
-        var encodedHome = Uri.EscapeDataString(home);
-        var encodedAway = Uri.EscapeDataString(away);
-        var encodedMessage = Uri.EscapeDataString(message ?? "Stream unavailable");
-        var route = $"/streams/{encodedLeague}/{encodedHome}/{encodedAway}?error={encodedMessage}";
-        Selection.LastRoute = route;
-        Navigation.NavigateTo(route, replace: true);
+        foreach (var part in query.TrimStart('?').Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = part.IndexOf('=');
+            if (eq <= 0)
+            {
+                continue;
+            }
+
+            if (!string.Equals(Uri.UnescapeDataString(part[..eq]), "error", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var error = Uri.UnescapeDataString(part[(eq + 1)..]);
+            if (!string.IsNullOrWhiteSpace(error))
+            {
+                ShowStreamPlaybackError(error);
+            }
+
+            return;
+        }
+    }
+
+    private void NavigateToStreamsWithError(string? message)
+    {
+        ShowStreamPlaybackError(message);
     }
 
     private async Task LoadGamesAsync()

--- a/VardyParty/Components/Pages/Home.razor.css
+++ b/VardyParty/Components/Pages/Home.razor.css
@@ -14,6 +14,7 @@
 
 .page-header {
     flex: 0 0 auto;
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.28);
 }
 
 .header-brand {
@@ -94,8 +95,92 @@ h1 {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    padding: 50px;
-    gap: 20px;
+    padding: 50px 24px;
+    gap: 12px;
+    text-align: center;
+}
+
+.empty-state-muted {
+    min-height: 0;
+    padding: 0;
+}
+
+.empty-state-title {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+
+.empty-state-text {
+    margin: 0;
+    max-width: 420px;
+    font-size: 15px;
+    line-height: 1.55;
+    color: var(--text-secondary);
+}
+
+.state-icon {
+    font-size: 40px;
+    line-height: 1;
+    margin-bottom: 4px;
+}
+
+.state-icon-loading {
+    width: 44px;
+    height: 44px;
+    border: 3px solid rgba(74, 158, 255, 0.2);
+    border-top-color: var(--primary-blue);
+    border-radius: 50%;
+    animation: spin 0.9s linear infinite;
+}
+
+.state-icon-auth {
+    font-size: 36px;
+}
+
+.auth-actions {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    justify-content: center;
+    flex-wrap: wrap;
+}
+
+.schedule-section {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 8px 20px 24px;
+    box-sizing: border-box;
+}
+
+.schedule-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 14px;
+    padding: 0 2px;
+}
+
+.schedule-title {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 700;
+    color: var(--text-primary);
+    letter-spacing: 0.01em;
+}
+
+.schedule-count {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-tertiary);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 999px;
+    padding: 4px 10px;
+    white-space: nowrap;
 }
 
 .status-message {
@@ -128,10 +213,8 @@ h1 {
 .games-grid {
     display: grid;
     grid-template-columns: 1fr;
-    gap: 15px;
-    padding: 16px 20px 20px;
-    max-width: 1200px;
-    margin: 0 auto;
+    gap: 12px;
+    padding: 0;
     width: 100%;
 }
 
@@ -434,9 +517,11 @@ h1 {
     flex-direction: column;
     align-items: center;
     gap: 16px;
-    padding: 16px;
-    border-radius: 8px;
-    background: linear-gradient(90deg, rgba(255,255,255,0.02), rgba(74,158,255,0.04));
+    padding: 28px 24px;
+    border-radius: 16px;
+    background: linear-gradient(145deg, rgba(74, 158, 255, 0.08), rgba(123, 90, 255, 0.06));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 12px 40px rgba(0, 0, 0, 0.22);
     width: min(960px, calc(100vw - 48px));
     margin: 24px auto;
     box-sizing: border-box;

--- a/VardyParty/Components/Pages/Home.razor.css
+++ b/VardyParty/Components/Pages/Home.razor.css
@@ -147,6 +147,12 @@ h1 {
     flex-wrap: wrap;
 }
 
+.auth-actions .auth-action:focus,
+.auth-actions .auth-action:focus-visible {
+    outline: 3px solid var(--primary-blue, #4a9eff);
+    outline-offset: 3px;
+}
+
 .schedule-section {
     width: 100%;
     max-width: 1200px;
@@ -527,6 +533,12 @@ h1 {
     box-sizing: border-box;
 }
 
+.auth-hero-device {
+    margin-top: 12px;
+    padding: 16px 20px;
+    gap: 12px;
+}
+
 .auth-hero-inner {
     width: 100%;
     display: flex;
@@ -538,19 +550,50 @@ h1 {
 .auth-device {
     width: 100%;
     display: flex;
-    flex-wrap: wrap;
+    flex-direction: column;
+    flex-wrap: nowrap;
     justify-content: center;
-    align-items: flex-start;
-    gap: 16px;
+    align-items: center;
+    gap: 10px;
+    text-align: center;
 }
 
-.auth-device > div {
-    min-width: 0;
-    max-width: 100%;
+.auth-device-copy {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    max-width: 36rem;
+}
+
+.auth-device-code {
+    font-size: 1.35rem;
+    font-weight: 700;
+    margin: 0;
+}
+
+.auth-device-uri {
+    font-size: 0.9rem;
+    opacity: 0.9;
+    margin: 0;
+    max-width: 36rem;
+    overflow-wrap: anywhere;
+}
+
+.auth-cancel {
+    min-width: 8rem;
+    min-height: 2.75rem;
+    font-size: 1.05rem;
+}
+
+.auth-cancel:focus,
+.auth-cancel:focus-visible {
+    outline: 3px solid var(--primary-blue, #4a9eff);
+    outline-offset: 3px;
 }
 
 .qr-image {
-    width: min(220px, 70vw);
+    width: min(200px, 42vh, 70vw);
     height: auto;
     max-width: 100%;
 }
@@ -567,7 +610,24 @@ h1 {
         margin-top: 20px;
     }
 
-    .qr-image {
-        width: 240px;
+    .auth-hero-device {
+        margin-top: 8px;
+        padding: 12px 16px;
     }
+
+    .qr-image {
+        width: min(220px, 40vh);
+    }
+}
+
+:global(.platform-android-tv) .auth-hero-device,
+.platform-android-tv .auth-hero-device {
+    margin-top: 4px;
+    margin-bottom: 0;
+    padding: 8px 16px 12px;
+}
+
+:global(.platform-android-tv) .qr-image,
+.platform-android-tv .qr-image {
+    width: min(180px, 36vh);
 }

--- a/VardyParty/Components/Pages/VideoPlayer.razor
+++ b/VardyParty/Components/Pages/VideoPlayer.razor
@@ -20,6 +20,10 @@
         <div class="stream-info-overlay">
             <div class="stream-info-content">
                 <div class="stream-counter">@displayState.DisplayText</div>
+                @if (!string.IsNullOrEmpty(displayState.CurrentStreamSourceLabel))
+                {
+                    <span class="source-badge source-badge-@displayState.CurrentStreamSourceLabel.ToLowerInvariant()">@displayState.CurrentStreamSourceLabel</span>
+                }
                 <div class="stream-channel">@displayState.CurrentStreamChannel</div>
             </div>
         </div>
@@ -80,6 +84,7 @@
         public int TotalHealthyStreams { get; set; }
         public int CurrentStreamIndex { get; set; }
         public string CurrentStreamChannel { get; set; } = string.Empty;
+        public string CurrentStreamSourceLabel { get; set; } = string.Empty;
         public bool IsVisible { get; set; }
         
         public string DisplayText => IsVisible 
@@ -133,6 +138,7 @@
             TotalHealthyStreams = streams.Count,
             CurrentStreamIndex = currentIndex,
             CurrentStreamChannel = currentStream?.Stream.Channel ?? "Unknown",
+            CurrentStreamSourceLabel = currentStream?.Stream.CatalogSourceBadgeLabel ?? string.Empty,
             IsVisible = streams.Count > 0
         };
         
@@ -231,16 +237,8 @@
 
     private void NavigateToStreamsWithError(string message)
     {
-        var league = string.IsNullOrEmpty(AppSelectionState.LastLeague) ? League : AppSelectionState.LastLeague;
-        var home = string.IsNullOrEmpty(AppSelectionState.LastHomeTeam) ? HomeTeam : AppSelectionState.LastHomeTeam;
-        var away = string.IsNullOrEmpty(AppSelectionState.LastAwayTeam) ? AwayTeam : AppSelectionState.LastAwayTeam;
-        var encodedLeague = Uri.EscapeDataString(league);
-        var encodedHome = Uri.EscapeDataString(home);
-        var encodedAway = Uri.EscapeDataString(away);
         var encodedMessage = Uri.EscapeDataString(message ?? "Stream unavailable");
-        var route = $"/streams/{encodedLeague}/{encodedHome}/{encodedAway}?error={encodedMessage}";
-        AppSelectionState.LastRoute = route;
-        Navigation.NavigateTo(route, replace: true);
+        Navigation.NavigateTo($"/?error={encodedMessage}", replace: true);
     }
 
     private void SetupRemoteKeyHandlers()

--- a/VardyParty/Components/Pages/VideoPlayer.razor.css
+++ b/VardyParty/Components/Pages/VideoPlayer.razor.css
@@ -67,6 +67,27 @@
     text-overflow: ellipsis;
 }
 
+.source-badge {
+    display: inline-block;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 1px 6px;
+    border-radius: 999px;
+    width: fit-content;
+}
+
+.source-badge-fb {
+    background: #1e3a5f;
+    color: #93c5fd;
+}
+
+.source-badge-v2 {
+    background: #3b0764;
+    color: #d8b4fe;
+}
+
 .status-panel {
     background: rgba(0,0,0,0.7);
     padding: 10px 14px;

--- a/VardyParty/Components/Shared/AppMenu.razor
+++ b/VardyParty/Components/Shared/AppMenu.razor
@@ -19,27 +19,18 @@
 <div class="app-menu-root">
 
     <button type="button"
-
             class="menu-button"
-
             aria-label="Open menu"
-
             aria-expanded="@isOpen"
-
+            tabindex="0"
             @ref="menuButtonRef"
-
-            @onclick="OpenMenu">
-
+            @onclick="OpenMenu"
+            @onkeydown="OnMenuButtonKeyDown">
         <span class="menu-button-icon" aria-hidden="true">
-
             <span></span>
-
             <span></span>
-
             <span></span>
-
         </span>
-
     </button>
 
 
@@ -63,17 +54,12 @@
                 </div>
 
                 <button type="button"
-
                         class="menu-close-button"
-
                         aria-label="Close menu"
-
+                        tabindex="0"
                         @ref="closeButtonRef"
-
                         @onclick="CloseMenu">
-
                     <span aria-hidden="true">×</span>
-
                 </button>
 
             </div>
@@ -135,45 +121,35 @@
                     {
 
                         <div class="league-filter-actions">
-
-                            <button type="button" class="menu-chip-button" @onclick="ShowAllLeagues">Show all</button>
-
-                            <button type="button" class="menu-chip-button menu-chip-button-muted" @onclick="ResetLeagueDefaults">Reset defaults</button>
-
+                            <button type="button"
+                                    class="menu-chip-button"
+                                    tabindex="0"
+                                    @ref="showAllButtonRef"
+                                    @onclick="ShowAllLeagues"
+                                    @onkeydown="OnShowAllKeyDown">Show all</button>
+                            <button type="button"
+                                    class="menu-chip-button menu-chip-button-muted"
+                                    tabindex="0"
+                                    @onclick="ResetLeagueDefaults"
+                                    @onkeydown="OnResetDefaultsKeyDown">Reset defaults</button>
                         </div>
-
                         <ul class="league-filter-list">
-
                             @foreach (var league in knownLeagues)
-
                             {
-
                                 var leagueName = league;
-
                                 var visible = LeagueFilter.IsLeagueVisible(leagueName);
-
                                 <li>
-
-                                    <label class="league-filter-item@(visible ? " league-filter-item-active" : string.Empty)">
-
-                                        <input type="checkbox"
-
-                                               class="league-filter-checkbox"
-
-                                               checked="@visible"
-
-                                               @onchange="e => OnLeagueToggle(leagueName, e)" />
-
+                                    <button type="button"
+                                            class="league-filter-item@(visible ? " league-filter-item-active" : string.Empty)"
+                                            tabindex="0"
+                                            aria-pressed="@visible"
+                                            @onclick="() => ToggleLeague(leagueName)"
+                                            @onkeydown="e => OnLeagueKeyDown(e, leagueName)">
                                         <span class="league-filter-check" aria-hidden="true"></span>
-
                                         <span class="league-filter-name">@leagueName</span>
-
-                                    </label>
-
+                                    </button>
                                 </li>
-
                             }
-
                         </ul>
 
                     }
@@ -184,12 +160,12 @@
 
                 <section class="flyout-menu-section flyout-menu-section-actions">
 
-                    <button type="button" class="menu-action-button menu-action-button-danger" @onclick="HandleSignOut">
-
+                    <button type="button"
+                            class="menu-action-button menu-action-button-danger"
+                            tabindex="0"
+                            @onclick="HandleSignOut">
                         <span class="section-icon" aria-hidden="true">⎋</span>
-
                         Sign out
-
                     </button>
 
                 </section>
@@ -229,6 +205,12 @@
     private ElementReference flyoutRef;
 
     private ElementReference closeButtonRef;
+
+    private ElementReference showAllButtonRef;
+
+    private string? lastToggleLeague;
+
+    private long lastToggleTimestampMs;
 
 
 
@@ -310,7 +292,22 @@
 
         {
 
-            await closeButtonRef.FocusAsync();
+            // TV: land in league controls so OK can toggle; Close is still reachable via D-pad Up.
+            if (isAuthenticated && knownLeagues.Count > 0)
+
+            {
+
+                await showAllButtonRef.FocusAsync();
+
+            }
+
+            else
+
+            {
+
+                await closeButtonRef.FocusAsync();
+
+            }
 
         }
 
@@ -322,13 +319,27 @@
 
             {
 
-                await menuButtonRef.FocusAsync();
+                await closeButtonRef.FocusAsync();
 
             }
 
             catch
 
             {
+
+                try
+
+                {
+
+                    await menuButtonRef.FocusAsync();
+
+                }
+
+                catch
+
+                {
+
+                }
 
             }
 
@@ -480,17 +491,52 @@
 
 
 
-    private void OnLeagueToggle(string league, ChangeEventArgs e)
-
+    private void ToggleLeague(string league)
     {
+        // Guard against TV OK firing both JS click assist and a native key activation.
+        var nowMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+        if (string.Equals(lastToggleLeague, league, StringComparison.Ordinal)
+            && nowMs - lastToggleTimestampMs < 350)
+        {
+            return;
+        }
 
-        var visible = e.Value is bool b && b;
-
-        LeagueFilter.SetLeagueVisible(league, visible);
-
+        lastToggleLeague = league;
+        lastToggleTimestampMs = nowMs;
+        LeagueFilter.SetLeagueVisible(league, !LeagueFilter.IsLeagueVisible(league));
     }
 
+    private void OnLeagueKeyDown(KeyboardEventArgs e, string league)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar" or "NumpadEnter")
+        {
+            ToggleLeague(league);
+        }
+    }
 
+    private void OnShowAllKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar" or "NumpadEnter")
+        {
+            ShowAllLeagues();
+        }
+    }
+
+    private void OnResetDefaultsKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar" or "NumpadEnter")
+        {
+            ResetLeagueDefaults();
+        }
+    }
+
+    private void OnMenuButtonKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key is "Enter" or " " or "Spacebar" or "NumpadEnter")
+        {
+            OpenMenu();
+        }
+    }
 
     private void ShowAllLeagues()
 
@@ -521,8 +567,6 @@
         await OnSignOut.InvokeAsync();
 
     }
-
-
 
     public void Dispose()
 

--- a/VardyParty/Components/Shared/AppMenu.razor
+++ b/VardyParty/Components/Shared/AppMenu.razor
@@ -1,0 +1,541 @@
+@using VardyParty.Models
+
+@using VardyParty.Providers
+
+@using VardyParty.Services
+
+@inject IEnrichedGameService GameService
+
+@inject ILeagueFilterService LeagueFilter
+
+@inject IBuildInfoService BuildInfoService
+
+@inject IAuthTokenProvider AuthTokenProvider
+
+@implements IDisposable
+
+
+
+<div class="app-menu-root">
+
+    <button type="button"
+
+            class="menu-button"
+
+            aria-label="Open menu"
+
+            aria-expanded="@isOpen"
+
+            @ref="menuButtonRef"
+
+            @onclick="OpenMenu">
+
+        <span class="menu-button-icon" aria-hidden="true">
+
+            <span></span>
+
+            <span></span>
+
+            <span></span>
+
+        </span>
+
+    </button>
+
+
+
+    @if (isOpen)
+
+    {
+
+        <div class="menu-backdrop no-drag" @onclick="CloseMenu"></div>
+
+        <nav class="flyout-menu no-drag" aria-label="Application menu" @ref="flyoutRef">
+
+            <div class="flyout-menu-header">
+
+                <div class="flyout-menu-brand">
+
+                    <span class="flyout-menu-brand-icon" aria-hidden="true">⚽</span>
+
+                    <span class="flyout-menu-title">Menu</span>
+
+                </div>
+
+                <button type="button"
+
+                        class="menu-close-button"
+
+                        aria-label="Close menu"
+
+                        @ref="closeButtonRef"
+
+                        @onclick="CloseMenu">
+
+                    <span aria-hidden="true">×</span>
+
+                </button>
+
+            </div>
+
+
+
+            @if (buildInfo is not null)
+
+            {
+
+                <section class="flyout-menu-section">
+
+                    <h2 class="flyout-menu-section-title">
+
+                        <span class="section-icon" aria-hidden="true">ℹ</span>
+
+                        Build
+
+                    </h2>
+
+                    <p class="flyout-build-info" title="Commit @buildInfo.Commit · @buildInfo.BuiltAtFull">
+
+                        <span class="build-version">v@(buildInfo.Version)</span>
+
+                        <span class="build-date">@buildInfo.BuiltAt</span>
+
+                    </p>
+
+                </section>
+
+            }
+
+
+
+            @if (isAuthenticated)
+
+            {
+
+                <section class="flyout-menu-section flyout-menu-section-leagues">
+
+                    <h2 class="flyout-menu-section-title">
+
+                        <span class="section-icon" aria-hidden="true">🏆</span>
+
+                        Leagues
+
+                    </h2>
+
+                    @if (knownLeagues.Count == 0)
+
+                    {
+
+                        <p class="flyout-menu-hint">Leagues appear once matches load.</p>
+
+                    }
+
+                    else
+
+                    {
+
+                        <div class="league-filter-actions">
+
+                            <button type="button" class="menu-chip-button" @onclick="ShowAllLeagues">Show all</button>
+
+                            <button type="button" class="menu-chip-button menu-chip-button-muted" @onclick="ResetLeagueDefaults">Reset defaults</button>
+
+                        </div>
+
+                        <ul class="league-filter-list">
+
+                            @foreach (var league in knownLeagues)
+
+                            {
+
+                                var leagueName = league;
+
+                                var visible = LeagueFilter.IsLeagueVisible(leagueName);
+
+                                <li>
+
+                                    <label class="league-filter-item@(visible ? " league-filter-item-active" : string.Empty)">
+
+                                        <input type="checkbox"
+
+                                               class="league-filter-checkbox"
+
+                                               checked="@visible"
+
+                                               @onchange="e => OnLeagueToggle(leagueName, e)" />
+
+                                        <span class="league-filter-check" aria-hidden="true"></span>
+
+                                        <span class="league-filter-name">@leagueName</span>
+
+                                    </label>
+
+                                </li>
+
+                            }
+
+                        </ul>
+
+                    }
+
+                </section>
+
+
+
+                <section class="flyout-menu-section flyout-menu-section-actions">
+
+                    <button type="button" class="menu-action-button menu-action-button-danger" @onclick="HandleSignOut">
+
+                        <span class="section-icon" aria-hidden="true">⎋</span>
+
+                        Sign out
+
+                    </button>
+
+                </section>
+
+            }
+
+        </nav>
+
+    }
+
+</div>
+
+
+
+@code {
+
+    [Parameter] public bool IsAuthenticated { get; set; }
+
+    [Parameter] public EventCallback OnSignOut { get; set; }
+
+
+
+    private bool isOpen;
+
+    private bool focusOnOpen;
+
+    private bool isAuthenticated;
+
+    private BuildInfo? buildInfo;
+
+    private IReadOnlyList<string> knownLeagues = Array.Empty<string>();
+
+    private IDisposable? _gamesSubscription;
+
+    private ElementReference menuButtonRef;
+
+    private ElementReference flyoutRef;
+
+    private ElementReference closeButtonRef;
+
+
+
+#if ANDROID
+
+    private void MenuBackHandler(global::Android.Views.Keycode keyCode)
+
+    {
+
+        if (!isOpen) return;
+
+
+
+        _ = InvokeAsync(() =>
+
+        {
+
+            CloseMenu();
+
+            StateHasChanged();
+
+        });
+
+    }
+
+#endif
+
+
+
+    protected override async Task OnInitializedAsync()
+
+    {
+
+        buildInfo = await BuildInfoService.GetAsync();
+
+        isAuthenticated = IsAuthenticated || await AuthTokenProvider.IsAuthenticatedAsync();
+
+
+
+        _gamesSubscription = GameService.GamesStream.Subscribe(OnGamesUpdated);
+
+        LeagueFilter.Changed += OnLeagueFilterChanged;
+
+        var latest = GameService.GetLatestGames();
+
+        if (latest != null)
+
+        {
+
+            OnGamesUpdated(latest);
+
+        }
+
+    }
+
+
+
+    protected override void OnParametersSet()
+
+    {
+
+        isAuthenticated = IsAuthenticated;
+
+    }
+
+
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+
+    {
+
+        if (!focusOnOpen || !isOpen) return;
+
+
+
+        focusOnOpen = false;
+
+        try
+
+        {
+
+            await closeButtonRef.FocusAsync();
+
+        }
+
+        catch
+
+        {
+
+            try
+
+            {
+
+                await menuButtonRef.FocusAsync();
+
+            }
+
+            catch
+
+            {
+
+            }
+
+        }
+
+    }
+
+
+
+    private void OnLeagueFilterChanged()
+
+    {
+
+        _ = InvokeAsync(StateHasChanged);
+
+    }
+
+
+
+    private void OnGamesUpdated(Dictionary<string, List<Game>>? gamesByLeague)
+
+    {
+
+        knownLeagues = LeagueFilter.GetKnownLeagues(gamesByLeague);
+
+        _ = InvokeAsync(StateHasChanged);
+
+    }
+
+
+
+    private void OpenMenu()
+
+    {
+
+        if (isOpen) return;
+
+
+
+        isOpen = true;
+
+        focusOnOpen = true;
+
+        RegisterMenuBackHandler();
+
+    }
+
+
+
+    private void CloseMenu()
+
+    {
+
+        if (!isOpen) return;
+
+
+
+        isOpen = false;
+
+        UnregisterMenuBackHandler();
+
+
+
+        _ = InvokeAsync(async () =>
+
+        {
+
+            StateHasChanged();
+
+            try
+
+            {
+
+                await menuButtonRef.FocusAsync();
+
+            }
+
+            catch
+
+            {
+
+            }
+
+        });
+
+    }
+
+
+
+    private void RegisterMenuBackHandler()
+
+    {
+
+#if ANDROID
+
+        try
+
+        {
+
+            MainActivity.SetFlyoutMenuOpen(true);
+
+            var remote = MainActivity.RemoteKeyHandler;
+
+            remote.OnBack -= MenuBackHandler;
+
+            remote.OnBack += MenuBackHandler;
+
+        }
+
+        catch
+
+        {
+
+        }
+
+#endif
+
+    }
+
+
+
+    private void UnregisterMenuBackHandler()
+
+    {
+
+#if ANDROID
+
+        try
+
+        {
+
+            MainActivity.SetFlyoutMenuOpen(false);
+
+            var remote = MainActivity.RemoteKeyHandler;
+
+            remote.OnBack -= MenuBackHandler;
+
+        }
+
+        catch
+
+        {
+
+        }
+
+#endif
+
+    }
+
+
+
+    private void OnLeagueToggle(string league, ChangeEventArgs e)
+
+    {
+
+        var visible = e.Value is bool b && b;
+
+        LeagueFilter.SetLeagueVisible(league, visible);
+
+    }
+
+
+
+    private void ShowAllLeagues()
+
+    {
+
+        LeagueFilter.SetLeaguesVisible(knownLeagues, true);
+
+    }
+
+
+
+    private void ResetLeagueDefaults()
+
+    {
+
+        LeagueFilter.ResetToDefaults();
+
+    }
+
+
+
+    private async Task HandleSignOut()
+
+    {
+
+        CloseMenu();
+
+        await OnSignOut.InvokeAsync();
+
+    }
+
+
+
+    public void Dispose()
+
+    {
+
+        UnregisterMenuBackHandler();
+
+        LeagueFilter.Changed -= OnLeagueFilterChanged;
+
+        _gamesSubscription?.Dispose();
+
+    }
+
+}
+
+

--- a/VardyParty/Components/Shared/VideoPlayerOverlay.razor
+++ b/VardyParty/Components/Shared/VideoPlayerOverlay.razor
@@ -36,6 +36,13 @@
                             <div class="stream-item @(isSelected ? "selected" : "")" 
                                  @onclick="() => SwitchStream(stream)">
                                 <span class="stream-name">@stream.Stream.Channel</span>
+                                @{
+                                    var sourceLabel = stream.Stream.CatalogSourceBadgeLabel;
+                                }
+                                @if (!string.IsNullOrEmpty(sourceLabel))
+                                {
+                                    <span class="source-badge source-badge-@sourceLabel.ToLowerInvariant()">@sourceLabel</span>
+                                }
                                 @if (!string.IsNullOrEmpty(stream.Stream.Reputation))
                                 {
                                     <span class="reputation">@stream.Stream.Reputation</span>
@@ -179,6 +186,27 @@
     .stream-name {
         font-weight: bold;
         font-size: 13px;
+    }
+
+    .source-badge {
+        display: inline-block;
+        font-size: 10px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.04em;
+        padding: 1px 6px;
+        border-radius: 999px;
+        width: fit-content;
+    }
+
+    .source-badge-fb {
+        background: #1e3a5f;
+        color: #93c5fd;
+    }
+
+    .source-badge-v2 {
+        background: #3b0764;
+        color: #d8b4fe;
     }
 
     .reputation {

--- a/VardyParty/MainPage.xaml.cs
+++ b/VardyParty/MainPage.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Components.WebView.Maui;
 using Microsoft.Maui.Controls;
+using System.Threading;
 #if WINDOWS
 using VardyParty.Platforms.Windows;
 using WinUiWindow = Microsoft.UI.Xaml.Window;
@@ -42,9 +43,27 @@ namespace VardyParty
                         {
                             Console.WriteLine("[MainPage] BlazorWebViewInitializing");
                         };
-                        blazorWebView.BlazorWebViewInitialized += (s, e) => 
+                        blazorWebView.BlazorWebViewInitialized += (s, e) =>
                         {
                             Console.WriteLine("[MainPage] BlazorWebViewInitialized - SUCCESS!");
+#if ANDROID
+                            try
+                            {
+                                if (e.WebView is Android.Webkit.WebView web)
+                                {
+                                    web.Focusable = true;
+                                    web.FocusableInTouchMode = true;
+                                    web.RequestFocus();
+                                    // Helps D-pad move between tabindex=0 game cards on Android TV.
+                                    web.Settings.SetSupportMultipleWindows(false);
+                                    Console.WriteLine($"[MainPage] WebView focusable (IsTv={MauiProgram.IsTv})");
+                                }
+                            }
+                            catch (Exception focusEx)
+                            {
+                                Console.WriteLine($"[MainPage] WebView focus setup failed: {focusEx.Message}");
+                            }
+#endif
                         };
                         blazorWebView.UrlLoading += (s, e) => 
                         {
@@ -153,6 +172,68 @@ namespace VardyParty
             return false;
 #endif
         }
+
+#if ANDROID
+        /// <summary>
+        /// Clicks the currently focused DOM element in the Blazor WebView.
+        /// Used for Android TV remotes where OK/Enter focuses a control but does not fire click.
+        /// Returns true when a real control was clicked so the key can be consumed (avoids double-toggle).
+        /// </summary>
+        public bool TryClickFocusedWebElement()
+        {
+            try
+            {
+                if (blazorWebView?.Handler?.PlatformView is not Android.Webkit.WebView web)
+                {
+                    return false;
+                }
+
+                // Only activate real controls — never treat a random focused node as success.
+                const string js =
+                    "(function(){var el=document.activeElement;" +
+                    "if(!el)return 'none';" +
+                    "var tag=(el.tagName||'').toLowerCase();" +
+                    "var role=(el.getAttribute('role')||'').toLowerCase();" +
+                    "if(tag==='button'||tag==='a'||role==='button')" +
+                    "{el.click();return tag;}" +
+                    "return 'skip:'+tag;})();";
+
+                string? jsResult = null;
+                using var done = new ManualResetEventSlim(false);
+                web.EvaluateJavascript(js, new JsStringCallback(value =>
+                {
+                    jsResult = value;
+                    done.Set();
+                }));
+
+                if (!done.Wait(TimeSpan.FromMilliseconds(250)))
+                {
+                    Console.WriteLine("[MainPage] TryClickFocusedWebElement timed out waiting for JS");
+                    return false;
+                }
+
+                // EvaluateJavascript string results are JSON-encoded (e.g. "\"button\"").
+                var normalized = (jsResult ?? string.Empty).Trim().Trim('"');
+                var clicked = normalized is "button" or "a";
+                Console.WriteLine($"[MainPage] TryClickFocusedWebElement result={normalized} clicked={clicked}");
+                return clicked;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[MainPage] TryClickFocusedWebElement failed: {ex.Message}");
+                return false;
+            }
+        }
+
+        private sealed class JsStringCallback : Java.Lang.Object, Android.Webkit.IValueCallback
+        {
+            private readonly Action<string?> _onResult;
+
+            public JsStringCallback(Action<string?> onResult) => _onResult = onResult;
+
+            public void OnReceiveValue(Java.Lang.Object? value) => _onResult(value?.ToString());
+        }
+#endif
 
         public void NavigateToRoute(string route)
         {

--- a/VardyParty/MauiProgram.cs
+++ b/VardyParty/MauiProgram.cs
@@ -1,9 +1,10 @@
-﻿using System.Net;
+using System.Net;
 using System.Net.Security;
 using System.Reflection;
 using Microsoft.AspNetCore.Components.WebView.Maui;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using VardyParty;
 using VardyParty.Components.Pages;
 using VardyParty.Configuration;
 using VardyParty.Exceptions;
@@ -159,6 +160,17 @@ public static class MauiProgram
         }
         
         builder.Configuration.AddSecrets(Assembly.GetExecutingAssembly());
+#if DEBUG
+        var previewBaseUrl = builder.Configuration["Api:HeadlessBaseUrl-Preview"];
+        if (!string.IsNullOrWhiteSpace(previewBaseUrl))
+        {
+            builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Api:HeadlessBaseUrl"] = previewBaseUrl
+            });
+            Console.WriteLine($"[MauiProgram] DEBUG: Using preview API at {previewBaseUrl}");
+        }
+#endif
         var apiSettings = builder.Configuration.GetSection(APISettings.SectionName).Get<APISettings>()
                           ?? throw new InvalidOperationException("Missing Api configuration section.");
 
@@ -249,7 +261,13 @@ public static class MauiProgram
             .ConfigurePrimaryHttpMessageHandler(() => CreateHeadlessHttpClientHandler(apiSettings));
         builder.Services.AddHttpClient<IApiService, ApiService>()
             .AddHttpMessageHandler<Auth0ApiTokenHandler>()
-            .ConfigurePrimaryHttpMessageHandler(() => CreateHeadlessHttpClientHandler(apiSettings));
+            .ConfigurePrimaryHttpMessageHandler(() => CreateHeadlessHttpClientHandler(apiSettings))
+            .ConfigureHttpClient(client =>
+            {
+                client.DefaultRequestHeaders.TryAddWithoutValidation(
+                    VardyPartyClientApiVersion.HeaderName,
+                    VardyPartyClientApiVersion.DefaultHeaderValue);
+            });
         builder.Services.AddHttpClient<IStreamHealthChecker, StreamHealthChecker>()
             .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
             {

--- a/VardyParty/MauiProgram.cs
+++ b/VardyParty/MauiProgram.cs
@@ -165,13 +165,14 @@ public static class MauiProgram
         
         builder.Configuration.AddSecrets(Assembly.GetExecutingAssembly());
 #if DEBUG
-        // Default to local wrangler for dev; set VARDYPARTY_DEBUG_API=preview to hit preview workers.
+        // Default to production; set VARDYPARTY_DEBUG_API=local|preview to override.
         var debugApiTarget = Environment.GetEnvironmentVariable("VARDYPARTY_DEBUG_API");
         var debugBaseUrl = debugApiTarget?.Trim().ToLowerInvariant() switch
         {
+            "local" => builder.Configuration["Api:HeadlessBaseUrl-Local"],
             "preview" => builder.Configuration["Api:HeadlessBaseUrl-Preview"],
             "production" or "prod" => builder.Configuration["Api:HeadlessBaseUrl"],
-            _ => builder.Configuration["Api:HeadlessBaseUrl-Local"],
+            _ => builder.Configuration["Api:HeadlessBaseUrl"],
         };
         if (!string.IsNullOrWhiteSpace(debugBaseUrl))
         {
@@ -179,7 +180,7 @@ public static class MauiProgram
             {
                 ["Api:HeadlessBaseUrl"] = debugBaseUrl
             });
-            Console.WriteLine($"[MauiProgram] DEBUG: Using API at {debugBaseUrl} (target={debugApiTarget ?? "local"})");
+            Console.WriteLine($"[MauiProgram] DEBUG: Using API at {debugBaseUrl} (target={debugApiTarget ?? "production"})");
         }
 #endif
         var apiSettings = builder.Configuration.GetSection(APISettings.SectionName).Get<APISettings>()

--- a/VardyParty/MauiProgram.cs
+++ b/VardyParty/MauiProgram.cs
@@ -18,6 +18,7 @@ using VardyParty.Platforms.Android;
 #endif
 using VardyParty.Providers;
 using VardyParty.Resolvers;
+using VardyParty.MauiServices;
 using VardyParty.Services;
 #if WINDOWS
 using Microsoft.Maui.Handlers;
@@ -91,6 +92,9 @@ public static class MauiProgram
 
     public static MauiApp CreateMauiApp()
     {
+#if WINDOWS
+        WindowsEventLogger.Info("MauiProgram", "CreateMauiApp starting");
+#endif
         var builder = MauiApp.CreateBuilder();
         builder
             .UseMauiApp<App>()
@@ -161,14 +165,21 @@ public static class MauiProgram
         
         builder.Configuration.AddSecrets(Assembly.GetExecutingAssembly());
 #if DEBUG
-        var previewBaseUrl = builder.Configuration["Api:HeadlessBaseUrl-Preview"];
-        if (!string.IsNullOrWhiteSpace(previewBaseUrl))
+        // Default to local wrangler for dev; set VARDYPARTY_DEBUG_API=preview to hit preview workers.
+        var debugApiTarget = Environment.GetEnvironmentVariable("VARDYPARTY_DEBUG_API");
+        var debugBaseUrl = debugApiTarget?.Trim().ToLowerInvariant() switch
+        {
+            "preview" => builder.Configuration["Api:HeadlessBaseUrl-Preview"],
+            "production" or "prod" => builder.Configuration["Api:HeadlessBaseUrl"],
+            _ => builder.Configuration["Api:HeadlessBaseUrl-Local"],
+        };
+        if (!string.IsNullOrWhiteSpace(debugBaseUrl))
         {
             builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
             {
-                ["Api:HeadlessBaseUrl"] = previewBaseUrl
+                ["Api:HeadlessBaseUrl"] = debugBaseUrl
             });
-            Console.WriteLine($"[MauiProgram] DEBUG: Using preview API at {previewBaseUrl}");
+            Console.WriteLine($"[MauiProgram] DEBUG: Using API at {debugBaseUrl} (target={debugApiTarget ?? "local"})");
         }
 #endif
         var apiSettings = builder.Configuration.GetSection(APISettings.SectionName).Get<APISettings>()
@@ -233,6 +244,8 @@ public static class MauiProgram
             .AddSingleton<IBbcHtmlParser, BbcHtmlParser>()
             .AddSingleton<IStreamDeduplicator, StreamDeduplicator>()
             .AddSingleton<IEnrichedGameService, EnrichedGameService>()
+            .AddSingleton<ILeagueFilterPreferencesStore, MauiLeagueFilterPreferencesStore>()
+            .AddSingleton<ILeagueFilterService, LeagueFilterService>()
             .AddSingleton<IHomePagePresentationService, HomePagePresentationService>()
             .AddSingleton<IStreamSwitchingService, StreamSwitchingService>()
             .AddSingleton<IStreamSelectionCoordinator, StreamSelectionCoordinator>()

--- a/VardyParty/Platforms/Android/AndroidManifest.xml
+++ b/VardyParty/Platforms/Android/AndroidManifest.xml
@@ -6,9 +6,9 @@
         android:supportsRtl="true"
         android:hardwareAccelerated="true"
         android:largeHeap="true"
-        android:icon="@drawable/banner"
-        android:roundIcon="@drawable/banner"
-        android:logo="@drawable/banner"
+        android:icon="@mipmap/appicon"
+        android:roundIcon="@mipmap/appicon_round"
+        android:logo="@mipmap/appicon"
         android:banner="@drawable/banner">
     </application>
     

--- a/VardyParty/Platforms/Android/AndroidVideoPlayerService.cs
+++ b/VardyParty/Platforms/Android/AndroidVideoPlayerService.cs
@@ -23,7 +23,8 @@ namespace VardyParty.Platforms.Android
             Func<Task>? onNextStreamRequested = null,
             string? league = null,
             string? homeTeam = null,
-            string? awayTeam = null)
+            string? awayTeam = null,
+            IReadOnlyDictionary<string, string>? requestHeaders = null)
         {
             try
             {

--- a/VardyParty/Platforms/Android/MainActivity.cs
+++ b/VardyParty/Platforms/Android/MainActivity.cs
@@ -18,11 +18,19 @@ namespace VardyParty
     public class MainActivity : MauiAppCompatActivity
     {
         private static bool _overlayBackSuppression;
+        private static bool _flyoutMenuOpen;
 
         public static void SetOverlayBackSuppression(bool suppress)
         {
             _overlayBackSuppression = suppress;
         }
+
+        public static void SetFlyoutMenuOpen(bool open)
+        {
+            _flyoutMenuOpen = open;
+        }
+
+        public static bool IsFlyoutMenuOpen => _flyoutMenuOpen;
         private static Platforms.Android.RemoteKeyHandler? _remoteKeyHandler;
 
         public static Platforms.Android.RemoteKeyHandler RemoteKeyHandler
@@ -51,6 +59,22 @@ namespace VardyParty
             {
                 _suppressNextBack = false;
                 Log.Info("MainActivity", "[MAIN] Back suppressed by overlay");
+                return;
+            }
+
+            if (_flyoutMenuOpen)
+            {
+                Log.Info("MainActivity", "[MAIN] Back pressed while flyout open - closing menu");
+                try
+                {
+                    if (RemoteKeyHandler.HandleKeyDown(Keycode.Back, null))
+                    {
+                        return;
+                    }
+                }
+                catch { }
+
+                SetFlyoutMenuOpen(false);
                 return;
             }
 
@@ -107,6 +131,12 @@ namespace VardyParty
 
         private void RemoteBackHandler(Keycode keyCode)
         {
+            if (_flyoutMenuOpen)
+            {
+                Log.Info("MainActivity", "[MAIN] Remote Back suppressed due to flyout menu");
+                return;
+            }
+
             // If an overlay (e.g., stream discovery) is active and intends to consume Back,
             // do not perform navigation here; let the overlay handler handle cancelation.
             if (_overlayBackSuppression)
@@ -183,24 +213,22 @@ namespace VardyParty
 
             if (segments[0].Equals("player", StringComparison.OrdinalIgnoreCase))
             {
-                if (segments.Count >= 4)
+            if (segments.Count >= 4)
+            {
+                var league = Uri.UnescapeDataString(segments[1]);
+                var home = Uri.UnescapeDataString(segments[2]);
+                var away = Uri.UnescapeDataString(segments[3]);
+                if (selection != null)
                 {
-                    var league = Uri.UnescapeDataString(segments[1]);
-                    var home = Uri.UnescapeDataString(segments[2]);
-                    var away = Uri.UnescapeDataString(segments[3]);
-                    var target = $"/streams/{Uri.EscapeDataString(league)}/{Uri.EscapeDataString(home)}/{Uri.EscapeDataString(away)}";
-                    if (selection != null)
-                    {
-                        selection.LastLeague = league;
-                        selection.LastHomeTeam = home;
-                        selection.LastAwayTeam = away;
-                        selection.LastRoute = target;
-                    }
-                    return target;
+                    selection.LastLeague = league;
+                    selection.LastHomeTeam = home;
+                    selection.LastAwayTeam = away;
+                    selection.LastRoute = "/";
                 }
+                return "/";
+            }
 
-                // Fallback if URL missing parts
-                return "/streams";
+            return "/";
             }
 
             if (segments[0].Equals("streams", StringComparison.OrdinalIgnoreCase))

--- a/VardyParty/Platforms/Android/NativeVideoActivity.cs
+++ b/VardyParty/Platforms/Android/NativeVideoActivity.cs
@@ -186,6 +186,7 @@ namespace VardyParty.Platforms.Android
         private TextView? _titleView;
         private TextView? _statusView;
         private TextView? _indexView;
+        private TextView? _sourceBadgeView;
         private TextView? _qualityView;
         private TextView? _resBrView;
         private global::Android.Views.View? _overlayContainer;
@@ -312,6 +313,14 @@ namespace VardyParty.Platforms.Android
             _indexView.SetTextSize(global::Android.Util.ComplexUnitType.Sp, bodySp);
             _indexView.SetTextColor(global::Android.Graphics.Color.White);
 
+            _sourceBadgeView = new TextView(this)
+            {
+                Visibility = global::Android.Views.ViewStates.Gone
+            };
+            _sourceBadgeView.SetTextSize(global::Android.Util.ComplexUnitType.Sp, smallSp);
+            _sourceBadgeView.SetTypeface(global::Android.Graphics.Typeface.DefaultBold, global::Android.Graphics.TypefaceStyle.Bold);
+            _sourceBadgeView.SetPadding((int)(6 * density), (int)(1 * density), (int)(6 * density), (int)(1 * density));
+
             _qualityView = new TextView(this);
             _qualityView.SetTextSize(global::Android.Util.ComplexUnitType.Sp, bodySp);
             _qualityView.SetTextColor(global::Android.Graphics.Color.White);
@@ -331,6 +340,7 @@ namespace VardyParty.Platforms.Android
             linear.AddView(_titleView);
             linear.AddView(_statusView);
             linear.AddView(_indexView);
+            linear.AddView(_sourceBadgeView);
             linear.AddView(_qualityView);
             linear.AddView(_resBrView);
             linear.Alpha = 0.95f;
@@ -867,6 +877,34 @@ namespace VardyParty.Platforms.Android
             }
         }
 
+        private void ApplySourceBadge(string? label)
+        {
+            if (_sourceBadgeView == null)
+            {
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(label))
+            {
+                _sourceBadgeView.Visibility = global::Android.Views.ViewStates.Gone;
+                return;
+            }
+
+            _sourceBadgeView.Text = label;
+            if (string.Equals(label, "FB", StringComparison.OrdinalIgnoreCase))
+            {
+                _sourceBadgeView.SetBackgroundColor(global::Android.Graphics.Color.ParseColor("#1e3a5f"));
+                _sourceBadgeView.SetTextColor(global::Android.Graphics.Color.ParseColor("#93c5fd"));
+            }
+            else
+            {
+                _sourceBadgeView.SetBackgroundColor(global::Android.Graphics.Color.ParseColor("#3b0764"));
+                _sourceBadgeView.SetTextColor(global::Android.Graphics.Color.ParseColor("#d8b4fe"));
+            }
+
+            _sourceBadgeView.Visibility = global::Android.Views.ViewStates.Visible;
+        }
+
         private static string? BuildAspect(string? resolution)
         {
             if (string.IsNullOrEmpty(resolution)) return null;
@@ -886,6 +924,7 @@ namespace VardyParty.Platforms.Android
                 if (_titleView != null) _titleView.Text = string.Empty;
                 if (_statusView != null) _statusView.Text = string.Empty;
                 if (_indexView != null) _indexView.Text = string.Empty;
+                if (_sourceBadgeView != null) _sourceBadgeView.Visibility = global::Android.Views.ViewStates.Gone;
                 if (_qualityView != null) _qualityView.Text = string.Empty;
                 if (_resBrView != null) _resBrView.Text = string.Empty;
                 return;
@@ -953,6 +992,7 @@ namespace VardyParty.Platforms.Android
             if (_titleView != null) _titleView.Text = BuildOverlayGameTitle(channel);
             if (_statusView != null) _statusView.Text = statusLine;
             if (_indexView != null) _indexView.Text = indexLine;
+            ApplySourceBadge(_switching?.GetCurrentStream()?.Stream?.CatalogSourceBadgeLabel);
             if (_qualityView != null) _qualityView.Text = qualityLabel;
             // Build lines: resolution (+fr), bitrate, buffer each on its own line
             var lines = new List<string>();
@@ -1181,7 +1221,7 @@ namespace VardyParty.Platforms.Android
                         _metricsWindow.AddBitrate(metrics.BitrateKbps.Value);
                     }
 
-                    await _healthReporter.ReportPlaybackMetricsAsync(_m3u8Url, _refererUrl, metrics);
+                    await _healthReporter.ReportPlaybackMetricsAsync(_m3u8Url, _refererUrl, metrics: metrics);
                 }
                 catch { }
             }, null, TimeSpan.FromSeconds(30), TimeSpan.FromSeconds(30));
@@ -1198,7 +1238,7 @@ namespace VardyParty.Platforms.Android
                     _metricsWindow.AddBitrate(metrics.BitrateKbps.Value);
                 }
 
-                _ = _healthReporter.ReportPlaybackStartedAsync(_m3u8Url, _refererUrl, metrics);
+                _ = _healthReporter.ReportPlaybackStartedAsync(_m3u8Url, _refererUrl, metrics: metrics);
             }
             catch { }
         }
@@ -1215,7 +1255,7 @@ namespace VardyParty.Platforms.Android
                     _metricsWindow.AddBitrate(metrics.BitrateKbps.Value);
                 }
 
-                _ = _healthReporter.ReportBufferingAsync(_m3u8Url, _refererUrl, metrics);
+                _ = _healthReporter.ReportBufferingAsync(_m3u8Url, _refererUrl, metrics: metrics);
             }
             catch { }
         }
@@ -1226,7 +1266,7 @@ namespace VardyParty.Platforms.Android
             try
             {
                 _metricsWindow.AddError();
-                _ = _healthReporter.ReportPlaybackErrorAsync(_m3u8Url, _refererUrl, error);
+                _ = _healthReporter.ReportPlaybackErrorAsync(_m3u8Url, _refererUrl, error: error);
             }
             catch { }
         }

--- a/VardyParty/Platforms/Android/RemoteKeyHandler.cs
+++ b/VardyParty/Platforms/Android/RemoteKeyHandler.cs
@@ -112,7 +112,21 @@ public class RemoteKeyHandler
             case Keycode.Enter:
             case Keycode.NumpadEnter:
                 OnEnter?.Invoke(keyCode);
-                return ShouldConsumeEnter?.Invoke() == true;
+                if (ShouldConsumeEnter?.Invoke() == true)
+                {
+                    return true;
+                }
+
+                // Assist TV WebView click. Consume only when a real control was activated —
+                // otherwise OK falls through (e.g. QR screen). Consuming after a click
+                // prevents Blazor @onclick from firing twice (league toggles looked dead).
+                if (global::VardyParty.MauiProgram.IsTv
+                    && global::VardyParty.MainPage.Instance?.TryClickFocusedWebElement() == true)
+                {
+                    return true;
+                }
+
+                return false;
 
             default:
                 return false;

--- a/VardyParty/Platforms/MacCatalyst/MacCatalystVideoPlayerService.cs
+++ b/VardyParty/Platforms/MacCatalyst/MacCatalystVideoPlayerService.cs
@@ -31,7 +31,8 @@ namespace VardyParty.Platforms.MacCatalyst
             Func<Task>? onNextStreamRequested = null,
             string? league = null,
             string? homeTeam = null,
-            string? awayTeam = null)
+            string? awayTeam = null,
+            IReadOnlyDictionary<string, string>? requestHeaders = null)
         {
             var tcs = new TaskCompletionSource<PlaybackResult>();
 
@@ -196,7 +197,7 @@ namespace VardyParty.Platforms.MacCatalyst
             // Report metadata if this is the first time we have format info
             if (!metadataReported && _currentMetrics?.Resolution.HasValue == true && healthReporter != null)
             {
-                _ = healthReporter.ReportPlaybackStartedAsync(m3u8Url, refererUrl, _currentMetrics);
+                _ = healthReporter.ReportPlaybackStartedAsync(m3u8Url, refererUrl, metrics: _currentMetrics);
             }
         }
 

--- a/VardyParty/Platforms/Windows/App.xaml.cs
+++ b/VardyParty/Platforms/Windows/App.xaml.cs
@@ -16,6 +16,7 @@ namespace VardyParty.WinUI
         {
             if (Auth0.OidcClient.Platforms.Windows.Activator.Default.CheckRedirectionActivation())
             {
+                Platforms.Windows.WindowsEventLogger.Info("WinUI.App", "Auth0 redirection activation handled; skipping main UI startup");
                 return;
             }
 

--- a/VardyParty/Platforms/Windows/WindowsVideoPlayerService.cs
+++ b/VardyParty/Platforms/Windows/WindowsVideoPlayerService.cs
@@ -68,7 +68,8 @@ namespace VardyParty.Platforms.Windows
             Func<Task>? onNextStreamRequested = null,
             string? league = null,
             string? homeTeam = null,
-            string? awayTeam = null)
+            string? awayTeam = null,
+            IReadOnlyDictionary<string, string>? requestHeaders = null)
         {
             var tcs = new TaskCompletionSource<PlaybackResult>();
 
@@ -223,7 +224,13 @@ namespace VardyParty.Platforms.Windows
                 bool isPointerNearNextButton = false;
                 bool isNextStreamRequestInProgress = false;
                 int playbackGeneration = 0;
+                int lastAttachedGeneration = 0;
+                bool hasEstablishedPlayback = false;
+                string? lastGoodPlaybackUrl = m3u8Url;
                 var playbackSwitchLock = new SemaphoreSlim(1, 1);
+                AdaptiveMediaSource? activeAdaptiveMediaSource = null;
+                TypedEventHandler<AdaptiveMediaSource, AdaptiveMediaSourceDownloadRequestedEventArgs>? activeDownloadHandler = null;
+                HttpClientWin? activePlaybackClient = null;
                 IStreamHealthReporter? _healthReporter = null;
                 
                 // Resolve health reporter
@@ -236,6 +243,23 @@ namespace VardyParty.Platforms.Windows
                 void StopTickerScroll()
                 {
                     try { scoresTickerScrollTimer?.Stop(); } catch { }
+                }
+
+                void ReleasePreviousPlaybackResources()
+                {
+                    if (activeAdaptiveMediaSource != null && activeDownloadHandler != null)
+                    {
+                        try { activeAdaptiveMediaSource.DownloadRequested -= activeDownloadHandler; } catch { }
+                    }
+
+                    activeAdaptiveMediaSource = null;
+                    activeDownloadHandler = null;
+
+                    if (activePlaybackClient != null)
+                    {
+                        try { activePlaybackClient.Dispose(); } catch { }
+                        activePlaybackClient = null;
+                    }
                 }
 
                 void CleanupMediaPlayer()
@@ -263,6 +287,8 @@ namespace VardyParty.Platforms.Windows
                             mediaPlayer.MediaFailed -= mediaFailedHandler;
                     }
                     catch { }
+
+                    ReleasePreviousPlaybackResources();
 
                     try
                     {
@@ -707,6 +733,7 @@ namespace VardyParty.Platforms.Windows
                         int streamTotal = 0;
                         string? streamChannel = null;
                         string? streamQuality = null;
+                        string? streamSourceLabel = null;
                         try
                         {
                             var switching = VardyParty.AppServiceProvider.ServiceProvider?.GetService(typeof(VardyParty.Services.IStreamSwitchingService)) as VardyParty.Services.IStreamSwitchingService;
@@ -717,6 +744,7 @@ namespace VardyParty.Platforms.Windows
                                 var current = switching.GetCurrentStream();
                                 streamChannel = current?.Stream?.Channel;
                                 try { streamQuality = current?.GetQualityDisplay(); } catch { }
+                                try { streamSourceLabel = current?.Stream?.CatalogSourceBadgeLabel; } catch { }
                             }
                         }
                         catch { }
@@ -726,6 +754,8 @@ namespace VardyParty.Platforms.Windows
                             sb.AppendLine($"Stream: {streamIndex}/{streamTotal}");
                         if (!string.IsNullOrEmpty(streamChannel))
                             sb.AppendLine($"Channel: {streamChannel}");
+                        if (!string.IsNullOrEmpty(streamSourceLabel))
+                            sb.AppendLine($"Source: {streamSourceLabel}");
                         if (!string.IsNullOrEmpty(streamQuality))
                             sb.AppendLine($"Quality: {streamQuality}");
                         sb.AppendLine($"Resolution: {width}x{height} @ {frameRateText}");
@@ -1399,40 +1429,88 @@ namespace VardyParty.Platforms.Windows
                 };
 
                 mediaEndedHandler = (s, e) => { Restore(); tcs.TrySetResult(PlaybackResult.Completed("Stream ended.", false)); };
+
+                void ShowStreamError(string message)
+                {
+                    MainThread.BeginInvokeOnMainThread(() =>
+                    {
+                        try
+                        {
+                            infoPanel.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+                            infoText.Text = message;
+                        }
+                        catch { }
+                    });
+                }
+
+                void ClosePlayerSession(string message)
+                {
+                    if (cleanupInvoked) return;
+                    Restore();
+                    tcs.TrySetResult(PlaybackResult.Completed(message, true));
+                }
+
+                async Task RevertToLastGoodStreamAsync(string reason)
+                {
+                    WindowsEventLogger.Warning("VideoPlayer", reason);
+                    ShowStreamError(reason);
+                    try { switchingService?.SwitchToPreviousStream(); } catch { }
+                    if (string.IsNullOrWhiteSpace(lastGoodPlaybackUrl)) return;
+                    await StartPlaybackAsync(lastGoodPlaybackUrl, force: true, isRevertAttempt: true);
+                }
+
+                async Task HandleActiveStreamFailureAsync(string message)
+                {
+                    WindowsEventLogger.Warning("VideoPlayer", message);
+                    ShowStreamError(message);
+                    try
+                    {
+                        if (onNextStreamRequested != null && !isNextStreamRequestInProgress)
+                        {
+                            isNextStreamRequestInProgress = true;
+                            try { await onNextStreamRequested(); }
+                            finally { isNextStreamRequestInProgress = false; }
+                            return;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        WindowsEventLogger.Error("VideoPlayer", "Auto-advance after stream failure failed", ex);
+                    }
+
+                    await RevertToLastGoodStreamAsync("Stream failed — reverted to previous stream.");
+                }
+
                 mediaFailedHandler = (s, e) =>
                 {
                     try
                     {
+                        if (cleanupInvoked) return;
+
                         var errMsg = e?.ErrorMessage ?? "Unknown media error";
                         var ext = string.Empty;
                         try { ext = e?.ExtendedErrorCode?.Message ?? string.Empty; } catch { }
+                        var detail = $"Media failed: {errMsg}\n{ext}";
 
-                        // Ensure we cleanup health checking so Home can restart
-                        try
+                        // Ignore stale failures from a source cleared during stream switch.
+                        if (playbackGeneration != lastAttachedGeneration)
                         {
-                            var svc = VardyParty.AppServiceProvider.ServiceProvider?.GetService(typeof(VardyParty.Services.IStreamSwitchingService)) as VardyParty.Services.IStreamSwitchingService;
-                            svc?.Cleanup();
+                            WindowsEventLogger.Info("VideoPlayer", $"Ignoring stale MediaFailed during switch: {errMsg}");
+                            return;
                         }
-                        catch { }
 
-                        MainThread.BeginInvokeOnMainThread(() =>
+                        if (hasEstablishedPlayback)
                         {
-                            try
-                            {
-                                infoPanel.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
-                                infoText.Text = $"Media failed: {errMsg}\n{ext}";
-                            }
-                            catch { }
-                        });
+                            _ = HandleActiveStreamFailureAsync(detail);
+                            return;
+                        }
 
-                        // Restore UI and signal failure so Home moves to next stream
-                        Restore();
-                        tcs.TrySetResult(PlaybackResult.Completed($"Stream error on Windows player. Error: '{errMsg}'. Extended-message: '{ext}'.", true));
+                        ClosePlayerSession($"Stream error on Windows player. Error: '{errMsg}'. Extended-message: '{ext}'.");
                     }
                     catch
                     {
-                        try { Restore(); } catch { }
-                        tcs.TrySetResult(PlaybackResult.Completed("Stream error on Windows player.", true));
+                        if (!hasEstablishedPlayback)
+                            ClosePlayerSession("Stream error on Windows player.");
                     }
                 };
 
@@ -1513,6 +1591,22 @@ namespace VardyParty.Platforms.Windows
                     Text = ""
                 };
                 streamInfoPanel.Children.Add(streamCountText);
+
+                var streamSourceBadge = new Microsoft.UI.Xaml.Controls.Border
+                {
+                    HorizontalAlignment = WinHorizontalAlignment.Right,
+                    CornerRadius = new Microsoft.UI.Xaml.CornerRadius(999),
+                    Padding = new WinThickness(6, 1, 6, 1),
+                    Margin = new WinThickness(0, 4, 0, 0),
+                    Visibility = Microsoft.UI.Xaml.Visibility.Collapsed
+                };
+                var streamSourceBadgeText = new Microsoft.UI.Xaml.Controls.TextBlock
+                {
+                    FontSize = 10,
+                    FontWeight = Microsoft.UI.Text.FontWeights.Bold
+                };
+                streamSourceBadge.Child = streamSourceBadgeText;
+                streamInfoPanel.Children.Add(streamSourceBadge);
 
                 // Next stream button host (button + x/y hint directly beneath)
                 var nextButtonContainer = new Microsoft.UI.Xaml.Controls.StackPanel
@@ -1809,6 +1903,31 @@ namespace VardyParty.Platforms.Windows
                                 streamCountText.Text = "Streams: 0";
                             }
 
+                            var sourceLabel = current?.Stream?.CatalogSourceBadgeLabel;
+                            if (!string.IsNullOrWhiteSpace(sourceLabel))
+                            {
+                                streamSourceBadgeText.Text = sourceLabel;
+                                if (string.Equals(sourceLabel, "FB", StringComparison.OrdinalIgnoreCase))
+                                {
+                                    streamSourceBadge.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                                        global::Windows.UI.Color.FromArgb(0xFF, 0x1E, 0x3A, 0x5F));
+                                    streamSourceBadgeText.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                                        global::Windows.UI.Color.FromArgb(0xFF, 0x93, 0xC5, 0xFD));
+                                }
+                                else
+                                {
+                                    streamSourceBadge.Background = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                                        global::Windows.UI.Color.FromArgb(0xFF, 0x3B, 0x07, 0x64));
+                                    streamSourceBadgeText.Foreground = new Microsoft.UI.Xaml.Media.SolidColorBrush(
+                                        global::Windows.UI.Color.FromArgb(0xFF, 0xD8, 0xB4, 0xFE));
+                                }
+                                streamSourceBadge.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
+                            }
+                            else
+                            {
+                                streamSourceBadge.Visibility = Microsoft.UI.Xaml.Visibility.Collapsed;
+                            }
+
                             var canSwitchToAnother = onNextStreamRequested != null && total > 1;
                             nextButtonHotZone.Visibility = canSwitchToAnother
                                 ? Microsoft.UI.Xaml.Visibility.Visible
@@ -1857,6 +1976,7 @@ namespace VardyParty.Platforms.Windows
                     if (generation != playbackGeneration || cleanupInvoked) return;
 
                     StopTickerScroll();
+                    ReleasePreviousPlaybackResources();
                     try
                     {
                         mediaPlayer.Pause();
@@ -1866,12 +1986,13 @@ namespace VardyParty.Platforms.Windows
                     catch { }
                 }
 
-                async Task StartPlaybackAsync(string url)
+                async Task StartPlaybackAsync(string url, bool force = false, bool isRevertAttempt = false)
                 {
                     await playbackSwitchLock.WaitAsync();
                     var generation = Interlocked.Increment(ref playbackGeneration);
                     int consecutiveDownloadFailures = 0;
                     const int MaxDownloadFailures = 5;
+                    string? pendingRevertMessage = null;
 
                     try
                     {
@@ -1880,21 +2001,11 @@ namespace VardyParty.Platforms.Windows
                             return;
 
                         var client = new HttpClientWin();
-                        client.DefaultRequestHeaders.Add("Referer", refererUrl);
-                        client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
+                        activePlaybackClient = client;
+                        ConfigurePlaybackHttpClient(client, refererUrl, requestHeaders);
 
-                        // Try standard creation first
                         var uri = new Uri(url);
-                        var adaptiveResult = await AdaptiveMediaSource.CreateFromUriAsync(uri, client);
-
-                        if (adaptiveResult.Status == AdaptiveMediaSourceCreationStatus.UnsupportedManifestContentType)
-                        {
-                            // Fallback: Download manifest manually and force content type
-                            var response = await client.GetAsync(uri);
-                            response.EnsureSuccessStatusCode();
-                            var stream = await response.Content.ReadAsInputStreamAsync();
-                            adaptiveResult = await AdaptiveMediaSource.CreateFromStreamAsync(stream, uri, "application/vnd.apple.mpegurl");
-                        }
+                        var adaptiveResult = await CreateAdaptiveMediaSourceAsync(client, uri);
 
                         if (adaptiveResult.Status != AdaptiveMediaSourceCreationStatus.Success || adaptiveResult.MediaSource == null)
                         {
@@ -1902,7 +2013,7 @@ namespace VardyParty.Platforms.Windows
                         }
 
                         // Attach handler to fix segment content types and ensure headers
-                        adaptiveResult.MediaSource.DownloadRequested += async (sender, args) =>
+                        TypedEventHandler<AdaptiveMediaSource, AdaptiveMediaSourceDownloadRequestedEventArgs> downloadHandler = async (sender, args) =>
                         {
                             if (generation != playbackGeneration || cleanupInvoked)
                                 return;
@@ -1918,8 +2029,7 @@ namespace VardyParty.Platforms.Windows
                                     if (generation != playbackGeneration || cleanupInvoked)
                                         return;
                                     var request = new global::Windows.Web.Http.HttpRequestMessage(global::Windows.Web.Http.HttpMethod.Get, args.ResourceUri);
-                                    request.Headers.TryAppendWithoutValidation("Referer", refererUrl);
-                                    request.Headers.TryAppendWithoutValidation("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36");
+                                    ApplyPlaybackRequestHeaders(request, refererUrl, requestHeaders);
 
                                     var response = await client.SendRequestAsync(request);
                                     response.EnsureSuccessStatusCode();
@@ -1989,12 +2099,16 @@ namespace VardyParty.Platforms.Windows
                                                 if (generation != playbackGeneration || cleanupInvoked)
                                                     return;
 
-                                                // Clear source to trigger MediaFailed event
+                                                var failureMessage =
+                                                    $"Stream failed after {MaxDownloadFailures} consecutive download errors (last: {statusCode})";
                                                 mediaPlayer.Source = null;
-                                                
-                                                // Manually trigger failure handling
-                                                Restore();
-                                                tcs.TrySetResult(PlaybackResult.Completed($"Stream failed after {MaxDownloadFailures} consecutive download errors (last: {statusCode})", true));
+
+                                                if (generation == lastAttachedGeneration && hasEstablishedPlayback)
+                                                    _ = HandleActiveStreamFailureAsync(failureMessage);
+                                                else if (hasEstablishedPlayback)
+                                                    _ = RevertToLastGoodStreamAsync($"Switch failed — {failureMessage}");
+                                                else
+                                                    ClosePlayerSession(failureMessage);
                                             }
                                             catch { }
                                         });
@@ -2013,6 +2127,10 @@ namespace VardyParty.Platforms.Windows
                                 }
                             }
                         };
+
+                        activeAdaptiveMediaSource = adaptiveResult.MediaSource;
+                        activeDownloadHandler = downloadHandler;
+                        adaptiveResult.MediaSource.DownloadRequested += downloadHandler;
 
                         var mediaSource = MediaSource.CreateFromAdaptiveMediaSource(adaptiveResult.MediaSource);
                         var playbackItem = new MediaPlaybackItem(mediaSource);
@@ -2046,6 +2164,9 @@ namespace VardyParty.Platforms.Windows
                                 }
 
                                 currentPlaybackUrl = url;
+                                lastAttachedGeneration = generation;
+                                hasEstablishedPlayback = true;
+                                lastGoodPlaybackUrl = url;
 
                                 // Ensure the grid is visible and hit testable
                                 playerGrid.Visibility = Microsoft.UI.Xaml.Visibility.Visible;
@@ -2064,8 +2185,10 @@ namespace VardyParty.Platforms.Windows
 
                                 WindowsEventLogger.Error("VideoPlayer", "Failed to attach playback source", ex);
                                 System.Diagnostics.Debug.WriteLine($"[Windows] Failed to attach playback source: {ex.GetType().Name} - {ex.Message}");
-                                Restore();
-                                tcs.TrySetResult(PlaybackResult.Completed($"Failed to attach playback source: {ex.Message}", true));
+                                if (hasEstablishedPlayback && !isRevertAttempt)
+                                    _ = RevertToLastGoodStreamAsync($"Failed to switch stream: {ex.Message}");
+                                else if (!hasEstablishedPlayback)
+                                    ClosePlayerSession($"Failed to attach playback source: {ex.Message}");
                             }
                         });
 
@@ -2076,15 +2199,20 @@ namespace VardyParty.Platforms.Windows
                         if (generation == playbackGeneration && !cleanupInvoked)
                         {
                             WindowsEventLogger.Error("VideoPlayer", "Failed to start playback", ex);
-                            Restore();
                             System.Diagnostics.Debug.WriteLine($"[Windows] Failed to start playback: {ex.GetType().Name} - {ex.Message}");
-                            tcs.TrySetResult(PlaybackResult.Completed($"Failed to start playback: {ex.Message}", true));
+                            if (hasEstablishedPlayback && !isRevertAttempt)
+                                pendingRevertMessage = $"Failed to switch stream: {ex.Message}";
+                            else if (!hasEstablishedPlayback)
+                                ClosePlayerSession($"Failed to start playback: {ex.Message}");
                         }
                     }
                     finally
                     {
                         playbackSwitchLock.Release();
                     }
+
+                    if (!string.IsNullOrWhiteSpace(pendingRevertMessage))
+                        await RevertToLastGoodStreamAsync(pendingRevertMessage);
                 }
 
                 async Task TrySwitchToCurrentStreamAsync(bool force = false)
@@ -2097,7 +2225,7 @@ namespace VardyParty.Platforms.Windows
                         if (string.IsNullOrWhiteSpace(url)) return;
                         if (!force && string.Equals(currentPlaybackUrl, url, StringComparison.OrdinalIgnoreCase)) return;
                         WindowsEventLogger.Info("VideoPlayer", $"Switching playback source (force={force})");
-                        await StartPlaybackAsync(url);
+                        await StartPlaybackAsync(url, force);
                     }
                     catch (Exception ex)
                     {
@@ -2350,6 +2478,94 @@ namespace VardyParty.Platforms.Windows
                 var hasAMS = mediaItem?.Source is MediaSource msCheck && msCheck.AdaptiveMediaSource != null;
                 var hasMetrics = _currentMetrics != null;
                 System.Diagnostics.Debug.WriteLine($"[Windows] Cannot update bitrate - mediaItem={hasMediaItem}, MediaSource={hasMediaSource}, AMS={hasAMS}, metrics={hasMetrics}");
+            }
+        }
+
+        private const string PlaybackUserAgent =
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36";
+
+        private static void ConfigurePlaybackHttpClient(
+            HttpClientWin client,
+            string refererUrl,
+            IReadOnlyDictionary<string, string>? requestHeaders = null)
+        {
+            foreach (var (name, value) in ResolvePlaybackHeaders(refererUrl, requestHeaders))
+            {
+                client.DefaultRequestHeaders.TryAppendWithoutValidation(name, value);
+            }
+        }
+
+        private static void ApplyPlaybackRequestHeaders(
+            global::Windows.Web.Http.HttpRequestMessage request,
+            string refererUrl,
+            IReadOnlyDictionary<string, string>? requestHeaders = null)
+        {
+            foreach (var (name, value) in ResolvePlaybackHeaders(refererUrl, requestHeaders))
+            {
+                request.Headers.TryAppendWithoutValidation(name, value);
+            }
+        }
+
+        private static IEnumerable<KeyValuePair<string, string>> ResolvePlaybackHeaders(
+            string refererUrl,
+            IReadOnlyDictionary<string, string>? requestHeaders)
+        {
+            if (requestHeaders is { Count: > 0 })
+            {
+                foreach (var pair in requestHeaders)
+                {
+                    if (!string.IsNullOrWhiteSpace(pair.Value))
+                    {
+                        yield return pair;
+                    }
+                }
+
+                yield break;
+            }
+
+            yield return new KeyValuePair<string, string>("User-Agent", PlaybackUserAgent);
+            if (string.IsNullOrWhiteSpace(refererUrl))
+            {
+                yield break;
+            }
+
+            yield return new KeyValuePair<string, string>("Referer", refererUrl);
+            if (Uri.TryCreate(refererUrl, UriKind.Absolute, out var refererUri))
+            {
+                yield return new KeyValuePair<string, string>(
+                    "Origin",
+                    $"{refererUri.Scheme}://{refererUri.Authority}");
+            }
+        }
+
+        private static async Task<AdaptiveMediaSourceCreationResult> CreateAdaptiveMediaSourceAsync(
+            HttpClientWin client,
+            Uri manifestUri)
+        {
+            var adaptiveResult = await AdaptiveMediaSource.CreateFromUriAsync(manifestUri, client);
+            if (adaptiveResult.Status == AdaptiveMediaSourceCreationStatus.Success && adaptiveResult.MediaSource != null)
+            {
+                return adaptiveResult;
+            }
+
+            WindowsEventLogger.Warning(
+                "VideoPlayer",
+                $"CreateFromUriAsync returned {adaptiveResult.Status}; downloading manifest with Referer/Origin");
+
+            try
+            {
+                var response = await client.GetAsync(manifestUri);
+                response.EnsureSuccessStatusCode();
+                var manifestStream = await response.Content.ReadAsInputStreamAsync();
+                return await AdaptiveMediaSource.CreateFromStreamAsync(
+                    manifestStream,
+                    manifestUri,
+                    "application/vnd.apple.mpegurl");
+            }
+            catch (Exception ex)
+            {
+                WindowsEventLogger.Error("VideoPlayer", "Manual manifest download failed", ex);
+                return adaptiveResult;
             }
         }
     }

--- a/VardyParty/Platforms/Windows/WindowsVideoPlayerService.cs
+++ b/VardyParty/Platforms/Windows/WindowsVideoPlayerService.cs
@@ -223,6 +223,7 @@ namespace VardyParty.Platforms.Windows
                 bool metadataReported = false;
                 bool isPointerNearNextButton = false;
                 bool isNextStreamRequestInProgress = false;
+                bool suppressIndexDrivenSwitch = false;
                 int playbackGeneration = 0;
                 int lastAttachedGeneration = 0;
                 bool hasEstablishedPlayback = false;
@@ -273,7 +274,6 @@ namespace VardyParty.Platforms.Windows
                         try { currentIndexSubscription?.Dispose(); } catch { }
                         try { gamesSubscription?.Dispose(); } catch { }
                         try { streamInfoHideTimer?.Stop(); } catch { }
-                        try { playbackSwitchLock.Dispose(); } catch { }
                         StopTickerScroll();
                         if (naturalVideoSizeChangedHandler != null)
                             mediaPlayer.PlaybackSession.NaturalVideoSizeChanged -= naturalVideoSizeChangedHandler;
@@ -309,6 +309,9 @@ namespace VardyParty.Platforms.Windows
                         mediaPlayer.Dispose();
                     }
                     catch { }
+
+                    // Dispose the switch lock last so in-flight StartPlaybackAsync can exit Wait/Release safely.
+                    try { playbackSwitchLock.Dispose(); } catch { }
                 }
                 // Top-left hamburger button — true top-left anchor, always visible in player
                 var menuButton = new WinButton
@@ -1454,9 +1457,93 @@ namespace VardyParty.Platforms.Windows
                 {
                     WindowsEventLogger.Warning("VideoPlayer", reason);
                     ShowStreamError(reason);
-                    try { switchingService?.SwitchToPreviousStream(); } catch { }
+                    // Do not call SwitchToPreviousStream here — that races CurrentStreamIndexChanged
+                    // against this forced attach and can leave the player on a cleared source.
                     if (string.IsNullOrWhiteSpace(lastGoodPlaybackUrl)) return;
                     await StartPlaybackAsync(lastGoodPlaybackUrl, force: true, isRevertAttempt: true);
+                }
+
+                async Task RecoverFromFailedSwitchAsync(string reason)
+                {
+                    WindowsEventLogger.Warning("VideoPlayer", reason);
+                    ShowStreamError(reason);
+
+                    suppressIndexDrivenSwitch = true;
+                    try
+                    {
+                        try
+                        {
+                            var failed = switchingService?.GetCurrentStream();
+                            if (failed != null)
+                            {
+                                failed.ResolvedM3U8Url = null;
+                            }
+
+                            // Drop the dead switch target so we don't keep cycling it.
+                            switchingService?.RemoveCurrentStream();
+                        }
+                        catch (Exception ex)
+                        {
+                            WindowsEventLogger.Error("VideoPlayer", "Failed to drop broken stream after switch failure", ex);
+                        }
+
+                        // Restore picture immediately from the last good manifest. Upcoming
+                        // candidates are background-prefetched so the next Next click stays fast.
+                        await RevertToLastGoodStreamAsync("Switch failed — reverted to last good stream.");
+                    }
+                    finally
+                    {
+                        suppressIndexDrivenSwitch = false;
+                    }
+                }
+
+                async Task RecoverFromFailedStartAsync(string reason)
+                {
+                    WindowsEventLogger.Warning("VideoPlayer", reason);
+                    ShowStreamError(reason);
+
+                    suppressIndexDrivenSwitch = true;
+                    try
+                    {
+                        try
+                        {
+                            var failed = switchingService?.GetCurrentStream();
+                            if (failed != null)
+                            {
+                                failed.ResolvedM3U8Url = null;
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            WindowsEventLogger.Error("VideoPlayer", "Failed to clear broken start URL", ex);
+                        }
+
+                        var remaining = switchingService?.GetHealthyStreams().Count ?? 0;
+                        if (onNextStreamRequested != null && remaining > 1 && !isNextStreamRequestInProgress)
+                        {
+                            isNextStreamRequestInProgress = true;
+                            try
+                            {
+                                // Advance to the next candidate with a fresh m3u8 resolve.
+                                await onNextStreamRequested();
+                                return;
+                            }
+                            catch (Exception ex)
+                            {
+                                WindowsEventLogger.Error("VideoPlayer", "Auto-advance after start failure failed", ex);
+                            }
+                            finally
+                            {
+                                isNextStreamRequestInProgress = false;
+                            }
+                        }
+
+                        ClosePlayerSession(reason);
+                    }
+                    finally
+                    {
+                        suppressIndexDrivenSwitch = false;
+                    }
                 }
 
                 async Task HandleActiveStreamFailureAsync(string message)
@@ -1478,7 +1565,7 @@ namespace VardyParty.Platforms.Windows
                         WindowsEventLogger.Error("VideoPlayer", "Auto-advance after stream failure failed", ex);
                     }
 
-                    await RevertToLastGoodStreamAsync("Stream failed — reverted to previous stream.");
+                    await RevertToLastGoodStreamAsync("Stream failed — reverted to last good stream.");
                 }
 
                 mediaFailedHandler = (s, e) =>
@@ -1988,29 +2075,56 @@ namespace VardyParty.Platforms.Windows
 
                 async Task StartPlaybackAsync(string url, bool force = false, bool isRevertAttempt = false)
                 {
-                    await playbackSwitchLock.WaitAsync();
+                    if (cleanupInvoked) return;
+
+                    try
+                    {
+                        await playbackSwitchLock.WaitAsync();
+                    }
+                    catch (ObjectDisposedException)
+                    {
+                        return;
+                    }
+
                     var generation = Interlocked.Increment(ref playbackGeneration);
                     int consecutiveDownloadFailures = 0;
                     const int MaxDownloadFailures = 5;
                     string? pendingRevertMessage = null;
+                    string? pendingStartFailureMessage = null;
 
                     try
                     {
-                        await MainThread.InvokeOnMainThreadAsync(() => PreparePlaybackSwitchOnUiThread(generation));
                         if (generation != playbackGeneration || cleanupInvoked)
                             return;
 
+                        // Build the adaptive source BEFORE clearing the current player source so a
+                        // failed switch does not leave the UI on a black frame.
                         var client = new HttpClientWin();
-                        activePlaybackClient = client;
                         ConfigurePlaybackHttpClient(client, refererUrl, requestHeaders);
 
                         var uri = new Uri(url);
                         var adaptiveResult = await CreateAdaptiveMediaSourceAsync(client, uri);
 
+                        if (cleanupInvoked || generation != playbackGeneration)
+                        {
+                            try { client.Dispose(); } catch { }
+                            return;
+                        }
+
                         if (adaptiveResult.Status != AdaptiveMediaSourceCreationStatus.Success || adaptiveResult.MediaSource == null)
                         {
+                            try { client.Dispose(); } catch { }
                             throw new InvalidOperationException($"Adaptive source failed: {adaptiveResult.Status}");
                         }
+
+                        await MainThread.InvokeOnMainThreadAsync(() => PreparePlaybackSwitchOnUiThread(generation));
+                        if (generation != playbackGeneration || cleanupInvoked)
+                        {
+                            try { client.Dispose(); } catch { }
+                            return;
+                        }
+
+                        activePlaybackClient = client;
 
                         // Attach handler to fix segment content types and ensure headers
                         TypedEventHandler<AdaptiveMediaSource, AdaptiveMediaSourceDownloadRequestedEventArgs> downloadHandler = async (sender, args) =>
@@ -2106,9 +2220,9 @@ namespace VardyParty.Platforms.Windows
                                                 if (generation == lastAttachedGeneration && hasEstablishedPlayback)
                                                     _ = HandleActiveStreamFailureAsync(failureMessage);
                                                 else if (hasEstablishedPlayback)
-                                                    _ = RevertToLastGoodStreamAsync($"Switch failed — {failureMessage}");
+                                                    _ = RecoverFromFailedSwitchAsync($"Switch failed — {failureMessage}");
                                                 else
-                                                    ClosePlayerSession(failureMessage);
+                                                    _ = RecoverFromFailedStartAsync(failureMessage);
                                             }
                                             catch { }
                                         });
@@ -2186,9 +2300,9 @@ namespace VardyParty.Platforms.Windows
                                 WindowsEventLogger.Error("VideoPlayer", "Failed to attach playback source", ex);
                                 System.Diagnostics.Debug.WriteLine($"[Windows] Failed to attach playback source: {ex.GetType().Name} - {ex.Message}");
                                 if (hasEstablishedPlayback && !isRevertAttempt)
-                                    _ = RevertToLastGoodStreamAsync($"Failed to switch stream: {ex.Message}");
+                                    _ = RecoverFromFailedSwitchAsync($"Failed to switch stream: {ex.Message}");
                                 else if (!hasEstablishedPlayback)
-                                    ClosePlayerSession($"Failed to attach playback source: {ex.Message}");
+                                    _ = RecoverFromFailedStartAsync($"Failed to attach playback source: {ex.Message}");
                             }
                         });
 
@@ -2203,21 +2317,34 @@ namespace VardyParty.Platforms.Windows
                             if (hasEstablishedPlayback && !isRevertAttempt)
                                 pendingRevertMessage = $"Failed to switch stream: {ex.Message}";
                             else if (!hasEstablishedPlayback)
-                                ClosePlayerSession($"Failed to start playback: {ex.Message}");
+                                pendingStartFailureMessage = $"Failed to start playback: {ex.Message}";
                         }
                     }
                     finally
                     {
-                        playbackSwitchLock.Release();
+                        try
+                        {
+                            if (!cleanupInvoked)
+                            {
+                                playbackSwitchLock.Release();
+                            }
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                        }
                     }
 
                     if (!string.IsNullOrWhiteSpace(pendingRevertMessage))
-                        await RevertToLastGoodStreamAsync(pendingRevertMessage);
+                        await RecoverFromFailedSwitchAsync(pendingRevertMessage);
+                    else if (!string.IsNullOrWhiteSpace(pendingStartFailureMessage))
+                        await RecoverFromFailedStartAsync(pendingStartFailureMessage);
                 }
 
                 async Task TrySwitchToCurrentStreamAsync(bool force = false)
                 {
                     if (switchingService == null || cleanupInvoked) return;
+                    if (suppressIndexDrivenSwitch) return;
+
                     try
                     {
                         var current = switchingService.GetCurrentStream();

--- a/VardyParty/Platforms/Windows/WindowsWindowDragHelper.cs
+++ b/VardyParty/Platforms/Windows/WindowsWindowDragHelper.cs
@@ -262,7 +262,7 @@ internal static class WindowsWindowDragHelper
 
                   function canDrag(el) {
                     if (!el) return false;
-                    if (el.closest('button,a,input,textarea,select,label,.game-card,.header-auth-button,[role="button"]')) {
+                    if (el.closest('button,a,input,textarea,select,label,.game-card,.header-auth-button,[role="button"],.flyout-menu,.menu-backdrop,.app-menu-root,.league-filter-list,.no-drag')) {
                       return false;
                     }
                     return !!el.closest('.page-shell,.auth-hero,#app');

--- a/VardyParty/Platforms/iOS/IOSVideoPlayerService.cs
+++ b/VardyParty/Platforms/iOS/IOSVideoPlayerService.cs
@@ -38,7 +38,8 @@ namespace VardyParty.Platforms.iOS
             Func<Task>? onNextStreamRequested = null,
             string? league = null,
             string? homeTeam = null,
-            string? awayTeam = null)
+            string? awayTeam = null,
+            IReadOnlyDictionary<string, string>? requestHeaders = null)
         {
             var tcs = new TaskCompletionSource<PlaybackResult>();
 

--- a/VardyParty/Properties/launchSettings.json
+++ b/VardyParty/Properties/launchSettings.json
@@ -1,11 +1,11 @@
 {
   "profiles": {
-    "Windows Machine": {
-      "commandName": "Project",
-      "nativeDebugging": false
-    },
     "MsixPackage": {
       "commandName": "MsixPackage",
+      "nativeDebugging": false
+    },
+    "Windows Machine": {
+      "commandName": "Project",
       "nativeDebugging": false
     }
   }

--- a/VardyParty/Resources/Raw/buildinfo.txt
+++ b/VardyParty/Resources/Raw/buildinfo.txt
@@ -1,2 +1,2 @@
-Commit=0db36e7
-Built=2026-07-01 15:49:26 UTC
+Commit=484ae5d
+Built=2026-07-04 23:13:00 UTC

--- a/VardyParty/Resources/Raw/buildinfo.txt
+++ b/VardyParty/Resources/Raw/buildinfo.txt
@@ -1,2 +1,2 @@
-Commit=c212e3f
-Built=2026-06-13 21:11:21 UTC
+Commit=0db36e7
+Built=2026-07-01 15:49:26 UTC

--- a/VardyParty/Services/Auth0AuthService.cs
+++ b/VardyParty/Services/Auth0AuthService.cs
@@ -128,11 +128,19 @@ public class Auth0AuthService(
 
     public async Task<AuthDeviceLoginResult?> StartDeviceLoginAsync(CancellationToken cancellationToken = default)
     {
-        if (_auth0Settings == null) return null;
+        if (_auth0Settings == null)
+        {
+            logger.LogWarning("[Auth0] Device login missing Auth0 settings instance");
+            throw new InvalidOperationException("Auth0 is not configured on this device build.");
+        }
 
         var clientId = _auth0Settings.ClientId;
         var domain = _auth0Settings.Domain;
-        if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(domain)) return null;
+        if (string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(domain))
+        {
+            logger.LogWarning("[Auth0] Device login missing ClientId/Domain");
+            throw new InvalidOperationException("Auth0 is not configured on this device build.");
+        }
 
         var client = httpClientFactory.CreateClient();
         var endpoint = BuildAuth0Url(domain, "/oauth/device/code");
@@ -147,13 +155,37 @@ public class Auth0AuthService(
         if (!string.IsNullOrWhiteSpace(_auth0Settings.Scope))
             form.Add(new KeyValuePair<string, string>("scope", _auth0Settings.Scope));
 
+        logger.LogInformation("[Auth0] Requesting device code from {Endpoint}", endpoint);
         using var response = await client.PostAsync(endpoint, new FormUrlEncodedContent(form), cancellationToken);
-        response.EnsureSuccessStatusCode();
+        var body = await response.Content.ReadAsStringAsync(cancellationToken);
 
-        var payload = await response.Content.ReadFromJsonAsync<DeviceCodeResponse>(cancellationToken);
+        if (!response.IsSuccessStatusCode)
+        {
+            var authError = TryReadOAuthError(body);
+            logger.LogWarning(
+                "[Auth0] Device code request failed: {Status} {Error} {Description} body={Body}",
+                (int)response.StatusCode,
+                authError?.Error,
+                authError?.ErrorDescription,
+                body.Length > 300 ? body[..300] : body);
+
+            var message = !string.IsNullOrWhiteSpace(authError?.ErrorDescription)
+                ? authError.ErrorDescription
+                : !string.IsNullOrWhiteSpace(authError?.Error)
+                    ? authError.Error
+                    : $"Sign-in failed ({(int)response.StatusCode}). Check Auth0 device-code grant.";
+            throw new InvalidOperationException(message);
+        }
+
+        var payload = System.Text.Json.JsonSerializer.Deserialize<DeviceCodeResponse>(body);
         if (payload == null || string.IsNullOrWhiteSpace(payload.DeviceCode) ||
             string.IsNullOrWhiteSpace(payload.UserCode) ||
-            string.IsNullOrWhiteSpace(payload.VerificationUri)) return null;
+            string.IsNullOrWhiteSpace(payload.VerificationUri))
+        {
+            logger.LogWarning("[Auth0] Device code response missing required fields: {Body}",
+                body.Length > 300 ? body[..300] : body);
+            throw new InvalidOperationException("Auth0 device sign-in returned an incomplete response.");
+        }
 
         var expiresAt = DateTimeOffset.UtcNow.AddSeconds(payload.ExpiresIn);
         var deviceCode = new AuthDeviceCode(
@@ -165,6 +197,7 @@ public class Auth0AuthService(
             payload.Interval <= 0 ? 5 : payload.Interval,
             expiresAt);
 
+        logger.LogInformation("[Auth0] Device code issued. UserCode={UserCode}", deviceCode.UserCode);
         return new AuthDeviceLoginResult(deviceCode);
     }
 
@@ -253,7 +286,7 @@ public class Auth0AuthService(
     public async Task LogoutAsync()
     {
         await ClearTokensAsync();
-        _auth0Settings = null;
+        // Do not null _auth0Settings — that permanently breaks device sign-in until process restart.
     }
 
     private bool IsExpired(Auth0Settings? settings)
@@ -444,6 +477,19 @@ public class Auth0AuthService(
         };
     }
 
+    private static OAuthErrorResponse? TryReadOAuthError(string body)
+    {
+        if (string.IsNullOrWhiteSpace(body)) return null;
+        try
+        {
+            return System.Text.Json.JsonSerializer.Deserialize<OAuthErrorResponse>(body);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     private static string BuildAuth0Url(string domain, string path)
     {
         var normalized = domain.Trim();
@@ -452,6 +498,13 @@ public class Auth0AuthService(
         return $"https://{normalized}{path}";
     }
 
+
+    private sealed class OAuthErrorResponse
+    {
+        [JsonPropertyName("error")] public string? Error { get; init; }
+
+        [JsonPropertyName("error_description")] public string? ErrorDescription { get; init; }
+    }
 
     private sealed class DeviceCodeResponse
     {

--- a/VardyParty/Services/BuildInfoService.cs
+++ b/VardyParty/Services/BuildInfoService.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Reflection;
 using System.Text;
 
@@ -12,6 +13,8 @@ public interface IBuildInfoService
 
 public class BuildInfoService : IBuildInfoService
 {
+    private static readonly char[] BuildInfoSeparators = ['\r', '\n', ';'];
+
     private BuildInfo? _cache;
 
     public async Task<BuildInfo> GetAsync()
@@ -22,27 +25,41 @@ public class BuildInfoService : IBuildInfoService
         }
 
         var version = GetVersionLabel();
-        // DLL last-write time reflects the binary actually running (including AppX sync).
-        var (builtAt, builtAtFull) = GetAssemblyBuiltAt();
-        var commit = await TryReadCommitAsync();
+        var (commit, builtRaw) = await TryReadBuildInfoFileAsync();
+        var (builtAt, builtAtFull) = FormatBuiltAt(builtRaw) ?? GetAssemblyBuiltAt();
 
         _cache = new BuildInfo(version, commit, builtAt, builtAtFull);
         return _cache;
     }
 
-    private static async Task<string> TryReadCommitAsync()
+    /// <summary>
+    /// Reads Commit/Built written by the GenerateBuildInfo MSBuild target at package time.
+    /// Prefer this over assembly file timestamps — Android APK entries often show 1601-01-01 / 00:00 UTC.
+    /// </summary>
+    private static async Task<(string Commit, string? Built)> TryReadBuildInfoFileAsync()
     {
+        var commit = "unknown";
+        string? built = null;
+
         try
         {
             using var stream = await FileSystem.OpenAppPackageFileAsync("buildinfo.txt");
             using var reader = new StreamReader(stream, Encoding.UTF8);
             var content = await reader.ReadToEndAsync();
-            foreach (var part in content.Split(';'))
+            foreach (var part in content.Split(BuildInfoSeparators, StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
             {
-                var kv = part.Split('=');
-                if (kv.Length == 2 && kv[0].Equals("Commit", StringComparison.OrdinalIgnoreCase))
+                var eq = part.IndexOf('=');
+                if (eq <= 0) continue;
+
+                var key = part[..eq].Trim();
+                var value = part[(eq + 1)..].Trim();
+                if (key.Equals("Commit", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(value))
                 {
-                    return kv[1].Trim();
+                    commit = value;
+                }
+                else if (key.Equals("Built", StringComparison.OrdinalIgnoreCase) && !string.IsNullOrWhiteSpace(value))
+                {
+                    built = value;
                 }
             }
         }
@@ -50,8 +67,42 @@ public class BuildInfoService : IBuildInfoService
         {
         }
 
-        return "unknown";
+        return (commit, built);
     }
+
+    private static (string Short, string Full)? FormatBuiltAt(string? builtRaw)
+    {
+        if (string.IsNullOrWhiteSpace(builtRaw))
+        {
+            return null;
+        }
+
+        // Written by MSBuild as: yyyy-MM-dd HH:mm:ss UTC
+        if (DateTime.TryParseExact(
+                builtRaw.Replace(" UTC", "", StringComparison.OrdinalIgnoreCase).Trim(),
+                "yyyy-MM-dd HH:mm:ss",
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
+                out var utc)
+            && IsPlausibleBuildTimestamp(utc))
+        {
+            return (utc.ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture),
+                utc.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture));
+        }
+
+        if (DateTime.TryParse(builtRaw, CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out utc)
+            && IsPlausibleBuildTimestamp(utc))
+        {
+            return (utc.ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture),
+                utc.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture));
+        }
+
+        // Keep the packaged string if we can't parse it.
+        return (builtRaw, builtRaw);
+    }
+
+    private static bool IsPlausibleBuildTimestamp(DateTime utc) => utc.Year >= 2020;
 
     private static string GetVersionLabel()
     {
@@ -78,7 +129,14 @@ public class BuildInfoService : IBuildInfoService
             }
 
             var utc = File.GetLastWriteTimeUtc(path);
-            return (utc.ToString("HH:mm 'UTC'"), utc.ToString("yyyy-MM-dd HH:mm:ss 'UTC'"));
+            if (!IsPlausibleBuildTimestamp(utc))
+            {
+                // Android APK / AOT assemblies often report Windows FILETIME epoch (1601-01-01).
+                return ("unknown", "unknown");
+            }
+
+            return (utc.ToString("yyyy-MM-dd HH:mm 'UTC'", CultureInfo.InvariantCulture),
+                utc.ToString("yyyy-MM-dd HH:mm:ss 'UTC'", CultureInfo.InvariantCulture));
         }
         catch
         {

--- a/VardyParty/Services/MauiLeagueFilterPreferencesStore.cs
+++ b/VardyParty/Services/MauiLeagueFilterPreferencesStore.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using Microsoft.Maui.Storage;
+using VardyParty.Services;
+
+namespace VardyParty.MauiServices;
+
+public class MauiLeagueFilterPreferencesStore : ILeagueFilterPreferencesStore
+{
+    private const string PreferencesKey = "league_filter_hidden";
+
+    public bool HasSavedPreferences => Preferences.ContainsKey(PreferencesKey);
+
+    public IReadOnlySet<string> LoadHiddenLeagues()
+    {
+        if (!HasSavedPreferences)
+        {
+            return new HashSet<string>(LeagueFilterDefaults.HiddenLeagues, StringComparer.OrdinalIgnoreCase);
+        }
+
+        var json = Preferences.Get(PreferencesKey, string.Empty);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        try
+        {
+            var leagues = JsonSerializer.Deserialize<List<string>>(json);
+            return new HashSet<string>(leagues ?? new List<string>(), StringComparer.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        }
+    }
+
+    public void SaveHiddenLeagues(IReadOnlySet<string> hiddenLeagues)
+    {
+        var json = JsonSerializer.Serialize(hiddenLeagues.OrderBy(l => l, StringComparer.OrdinalIgnoreCase).ToList());
+        Preferences.Set(PreferencesKey, json);
+    }
+
+    public void ClearSavedPreferences()
+    {
+        Preferences.Remove(PreferencesKey);
+    }
+}

--- a/VardyParty/VardyParty.csproj
+++ b/VardyParty/VardyParty.csproj
@@ -340,6 +340,44 @@
       <Copy SourceFiles="@(_AppXWwwroot)"
             DestinationFiles="@(_AppXWwwroot->'$(_AppXRoot)wwwroot\%(RecursiveDir)%(Filename)%(Extension)')"
             SkipUnchangedFiles="false" />
+      <!-- Unpackaged dotnet run resolves HostPage from OutputPath\wwwroot; mirror AppX Blazor assets there. -->
+      <ItemGroup>
+        <_AppXFramework Include="$(_AppXRoot)wwwroot\_framework\**\*.*" Condition="Exists('$(_AppXRoot)wwwroot\_framework')" />
+      </ItemGroup>
+      <Copy SourceFiles="@(_AppXFramework)"
+            DestinationFiles="@(_AppXFramework->'$(_WinOutputRoot)wwwroot\_framework\%(RecursiveDir)%(Filename)%(Extension)')"
+            SkipUnchangedFiles="false"
+            Condition="'@(_AppXFramework)' != ''" />
+      <Copy SourceFiles="$(_AppXRoot)wwwroot\index.html"
+            DestinationFiles="$(_WinOutputRoot)wwwroot\index.html"
+            SkipUnchangedFiles="false"
+            Condition="Exists('$(_AppXRoot)wwwroot\index.html')" />
+      <Copy SourceFiles="$(_AppXRoot)wwwroot\VardyParty.styles.css"
+            DestinationFiles="$(_WinOutputRoot)wwwroot\VardyParty.styles.css"
+            SkipUnchangedFiles="false"
+            Condition="Exists('$(_AppXRoot)wwwroot\VardyParty.styles.css')" />
+      <!-- Maui splash/tile PNGs: refresh AppX from resizetizer, then mirror beside AppxManifest for loose-register. -->
+      <ItemGroup>
+        <_ResizetizerPng Include="$(IntermediateOutputPath)resizetizer\sp\*.png;$(IntermediateOutputPath)resizetizer\r\*.png" />
+        <_MsixAssetBase Include="vardyparty_splashStoreLogo;vardyparty_splashMediumTile;vardyparty_splashLogo;vardyparty_splashSmallTile;vardyparty_splashWideTile;vardyparty_splashLargeTile;vardyparty_splash_generatedSplashScreen" />
+        <_MsixAssetScale100 Include="@(_MsixAssetBase->'$(_AppXRoot)%(Identity).scale-100.png')"
+                             Condition="Exists('$(_AppXRoot)%(Identity).scale-100.png')">
+          <_Dest>$(_AppXRoot)%(Identity).png</_Dest>
+        </_MsixAssetScale100>
+        <_AppXLooseAsset Include="$(_AppXRoot)*.png;$(_AppXRoot)resources.pri" />
+      </ItemGroup>
+      <Copy SourceFiles="@(_ResizetizerPng)"
+            DestinationFolder="$(_AppXRoot)"
+            SkipUnchangedFiles="false"
+            Condition="'@(_ResizetizerPng)' != ''" />
+      <Copy SourceFiles="@(_MsixAssetScale100)"
+            DestinationFiles="%(_MsixAssetScale100._Dest)"
+            SkipUnchangedFiles="false"
+            Condition="'@(_MsixAssetScale100)' != ''" />
+      <Copy SourceFiles="@(_AppXLooseAsset)"
+            DestinationFolder="$(_WinOutputRoot)"
+            SkipUnchangedFiles="false"
+            Condition="'@(_AppXLooseAsset)' != ''" />
     </Target>
 
     <!-- Keep MSIX loose-layout wwwroot in sync with league logo assets (AppX folder is not always refreshed on incremental builds). -->

--- a/VardyParty/VardyParty.csproj
+++ b/VardyParty/VardyParty.csproj
@@ -76,10 +76,6 @@
         <InvariantGlobalization>true</InvariantGlobalization>
     </PropertyGroup>
 
-    <PropertyGroup>
-      <BuildTimestamp>$([System.DateTime]::UtcNow.ToString("yyyy-MM-dd HH:mm:ss 'UTC'"))</BuildTimestamp>
-    </PropertyGroup>
-
     <PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios' or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
       <UseMonoRuntime>true</UseMonoRuntime>
     </PropertyGroup>
@@ -90,6 +86,10 @@
 
     <!-- GenerateBuildInfo: always on Debug; Release via RunGenerateBuildInfo=true (CI publish). -->
     <Target Name="GenerateBuildInfo" BeforeTargets="ProcessMauiAssets" Condition="'$(RunGenerateBuildInfo)' == 'true' Or '$(Configuration)' == 'Debug'">
+      <!-- Capture UTC now at target run time (not project-eval time) so package stamps are accurate. -->
+      <PropertyGroup>
+        <BuildTimestamp>$([System.DateTime]::UtcNow.ToString("yyyy-MM-dd HH:mm:ss")) UTC</BuildTimestamp>
+      </PropertyGroup>
       <Exec Command="git rev-parse --short HEAD" WorkingDirectory="$(MSBuildProjectDirectory)" ConsoleToMSBuild="true" IgnoreExitCode="true">
         <Output TaskParameter="ConsoleOutput" PropertyName="GitHashOutput" />
       </Exec>
@@ -98,15 +98,20 @@
         <GitHash Condition=" '$(GitHash)' == '' ">unknown</GitHash>
       </PropertyGroup>
       <ItemGroup>
-        <_BuildInfoLine Include="Commit=$(GitHash);Built=$(BuildTimestamp)" />
+        <!-- Semicolon would split into two MSBuild items; write one key per line instead. -->
+        <_BuildInfoLine Include="Commit=$(GitHash)" />
+        <_BuildInfoLine Include="Built=$(BuildTimestamp)" />
       </ItemGroup>
       <WriteLinesToFile File="$(MSBuildProjectDirectory)\Resources\Raw\buildinfo.txt" Lines="@(_BuildInfoLine)" Overwrite="true" />
+      <Message Importance="high" Text="GenerateBuildInfo: $(BuildTimestamp) commit=$(GitHash)" />
     </Target>
 
     <!-- GenerateSplashWithBuildInfo disabled by default; enable by setting RunGenerateSplash=true -->
-    <Target Name="GenerateSplashWithBuildInfo" BeforeTargets="ProcessMauiAssets" Condition="'$(RunGenerateSplash)' == 'true'">
+    <Target Name="GenerateSplashWithBuildInfo" BeforeTargets="ProcessMauiAssets" DependsOnTargets="GenerateBuildInfo" Condition="'$(RunGenerateSplash)' == 'true'">
       <PropertyGroup>
         <SplashFile>$(MSBuildProjectDirectory)\Resources\Splash\vardyparty_splash_generated.svg</SplashFile>
+        <BuildTimestamp Condition="'$(BuildTimestamp)' == ''">$([System.DateTime]::UtcNow.ToString("yyyy-MM-dd HH:mm:ss")) UTC</BuildTimestamp>
+        <GitHash Condition="'$(GitHash)' == ''">unknown</GitHash>
       </PropertyGroup>
       <MakeDir Directories="$(MSBuildProjectDirectory)\Resources\Splash" />
       <ItemGroup>
@@ -151,18 +156,17 @@
     </ItemGroup>
 
     <ItemGroup>
-        <!-- App Icon - Custom VardyParty Icon -->
+        <!-- App Icon: Windows keeps splash-derived tiles; Android/iOS use adaptive square icon -->
         <MauiIcon Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'" Include="Resources\Splash\vardyparty_splash.svg" Color="#003090" />
-
-        <!-- Splash Screen - Custom VardyParty Splash -->
-        <!-- Use generated splash with build info -->
+        <MauiIcon Include="Resources\AppIcon\appicon.svg" ForegroundFile="Resources\AppIcon\appiconfg.svg" Color="#003090" ForegroundScale="0.92" />
 
         <!-- Images -->
         <MauiImage Include="Resources\Images\*" />
         <Content Include="Resources\Images\Leagues\**\*.*" Link="wwwroot\images\leagues\%(RecursiveDir)%(Filename)%(Extension)" CopyToOutputDirectory="PreserveNewest" />
         
-        <!-- Android TV Banner -->
+        <!-- Android TV Banner (wide asset — not the phone launcher icon) -->
         <MauiImage Include="Resources\AppIcon\banner.svg" BaseSize="320,180" />
+
 
         <!-- Custom Fonts -->
         <MauiFont Include="Resources\Fonts\*" />

--- a/VardyParty/appsettings.json
+++ b/VardyParty/appsettings.json
@@ -26,7 +26,7 @@
     "Auth0":  {
                   "Domain":  "jonbreen.uk.auth0.com",
                   "ClientId":  "Q1kwNW2bFbIE4tbk0pOc1cDjxIKJceKF",
-                  "Audience":  "https://headless-m3u8-preview.jonbreen.workers.dev/",
+                  "Audience":  "https://headless-m3u8.jonbreen.workers.dev/",
                   "Scope":  "openid profile email offline_access",
                   "CallbackScheme":  "vardyparty",
                   "RedirectUri":  "vardyparty://callback",
@@ -36,8 +36,8 @@
                   "RequiredRole":  "stream-viewer"
               },
     "Api":  {
-                "HeadlessBaseUrl-Local":  "https://192.168.1.251:8787/",
-                "HeadlessBaseUrl":  "https://headless-m3u8-preview.jonbreen.workers.dev/",
+                "HeadlessBaseUrl-Local":  "https://127.0.0.1:8787/",
+                "HeadlessBaseUrl":  "https://headless-m3u8.jonbreen.workers.dev/",
                 "HeadlessBaseUrl-Preview":  "https://headless-m3u8-preview.jonbreen.workers.dev/",
                 "IgnoreSslCertificateErrors":  true
             }

--- a/VardyParty/appsettings.json
+++ b/VardyParty/appsettings.json
@@ -26,7 +26,7 @@
     "Auth0":  {
                   "Domain":  "jonbreen.uk.auth0.com",
                   "ClientId":  "Q1kwNW2bFbIE4tbk0pOc1cDjxIKJceKF",
-                  "Audience":  "https://headless-m3u8.jonbreen.workers.dev/",
+                  "Audience":  "https://headless-m3u8-preview.jonbreen.workers.dev/",
                   "Scope":  "openid profile email offline_access",
                   "CallbackScheme":  "vardyparty",
                   "RedirectUri":  "vardyparty://callback",
@@ -37,7 +37,7 @@
               },
     "Api":  {
                 "HeadlessBaseUrl-Local":  "https://192.168.1.251:8787/",
-                "HeadlessBaseUrl":  "https://headless-m3u8.jonbreen.workers.dev/",
+                "HeadlessBaseUrl":  "https://headless-m3u8-preview.jonbreen.workers.dev/",
                 "HeadlessBaseUrl-Preview":  "https://headless-m3u8-preview.jonbreen.workers.dev/",
                 "IgnoreSslCertificateErrors":  true
             }

--- a/VardyParty/wwwroot/css/app.css
+++ b/VardyParty/wwwroot/css/app.css
@@ -163,13 +163,18 @@ button {
 }
 
 .platform-windows .page-header-inner {
-    padding-right: 150px;
+    padding-right: 80px;
 }
 
 .header-left {
+    position: absolute;
+    left: 16px;
+    top: 0;
+    bottom: 0;
     display: flex;
     align-items: center;
     gap: 8px;
+    z-index: 2;
 }
 
 .header-title {
@@ -383,9 +388,12 @@ button {
 }
 
 .welcome-text {
-    font-size: 18px;
-    color: var(--text-secondary);
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--text-primary);
     margin: 0;
+    text-align: center;
+    line-height: 1.4;
 }
 
 /* Loading State */
@@ -474,6 +482,369 @@ button {
     padding: 20px;
 }
 
+/* Hamburger menu */
+.app-menu-root {
+    position: relative;
+}
+
+.menu-button {
+    background: rgba(255, 255, 255, 0.08);
+    color: white;
+    border: 1px solid rgba(255, 255, 255, 0.28);
+    border-radius: 10px;
+    width: 44px;
+    height: 44px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.menu-button-icon {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+    width: 18px;
+}
+
+.menu-button-icon span {
+    display: block;
+    height: 2px;
+    width: 100%;
+    background: currentColor;
+    border-radius: 2px;
+}
+
+.menu-button:hover,
+.menu-button:focus-visible {
+    background: rgba(255, 255, 255, 0.16);
+    border-color: rgba(255, 255, 255, 0.5);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.45);
+    transform: scale(1.04);
+}
+
+.menu-backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.55);
+    backdrop-filter: blur(2px);
+    z-index: 200;
+}
+
+.flyout-menu {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(360px, 90vw);
+    height: 100vh;
+    height: 100dvh;
+    max-height: none;
+    margin: 0;
+    border-radius: 0;
+    background: linear-gradient(180deg, #1e2430 0%, #141820 48%, #101218 100%);
+    color: var(--text-primary);
+    border-right: 1px solid rgba(74, 158, 255, 0.22);
+    box-shadow: 12px 0 40px rgba(0, 0, 0, 0.45);
+    z-index: 201;
+    overflow-y: auto;
+    overflow-x: hidden;
+    padding: 0;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+}
+
+.flyout-menu-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 20px 18px 16px;
+    background: linear-gradient(135deg, rgba(74, 158, 255, 0.18), rgba(123, 90, 255, 0.12));
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.flyout-menu-brand {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
+
+.flyout-menu-brand-icon {
+    font-size: 22px;
+    line-height: 1;
+}
+
+.flyout-menu-title {
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: 0.01em;
+}
+
+.menu-close-button {
+    background: rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    color: var(--text-secondary);
+    font-size: 26px;
+    line-height: 1;
+    cursor: pointer;
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.menu-close-button:hover,
+.menu-close-button:focus-visible {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: rgba(74, 158, 255, 0.55);
+    color: var(--text-primary);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.4);
+}
+
+.flyout-menu-section {
+    border-top: 1px solid rgba(255, 255, 255, 0.06);
+    padding: 16px 18px;
+}
+
+.flyout-menu-section-leagues {
+    flex: 1 1 auto;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.flyout-menu-section-title {
+    margin: 0 0 12px;
+    font-size: 11px;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--text-tertiary);
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.section-icon {
+    font-size: 14px;
+    opacity: 0.85;
+}
+
+.flyout-build-info {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-size: 14px;
+    color: var(--text-secondary);
+    font-variant-numeric: tabular-nums;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-radius: 10px;
+    padding: 10px 12px;
+}
+
+.build-version {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.build-date {
+    font-size: 12px;
+    color: var(--text-tertiary);
+}
+
+.flyout-menu-hint {
+    margin: 0;
+    font-size: 14px;
+    color: var(--text-tertiary);
+    line-height: 1.5;
+    padding: 10px 12px;
+    background: rgba(255, 255, 255, 0.03);
+    border-radius: 10px;
+    border: 1px dashed rgba(255, 255, 255, 0.1);
+}
+
+.league-filter-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin-bottom: 12px;
+}
+
+.menu-chip-button {
+    background: rgba(74, 158, 255, 0.14);
+    border: 1px solid rgba(74, 158, 255, 0.35);
+    color: #b9d9ff;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    padding: 8px 12px;
+    border-radius: 999px;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.menu-chip-button-muted {
+    background: rgba(255, 255, 255, 0.04);
+    border-color: rgba(255, 255, 255, 0.14);
+    color: var(--text-secondary);
+}
+
+.menu-chip-button:hover,
+.menu-chip-button:focus-visible {
+    background: rgba(74, 158, 255, 0.24);
+    border-color: rgba(74, 158, 255, 0.6);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.35);
+}
+
+.menu-chip-button-muted:hover,
+.menu-chip-button-muted:focus-visible {
+    background: rgba(255, 255, 255, 0.08);
+    border-color: rgba(255, 255, 255, 0.28);
+    box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.12);
+}
+
+.league-filter-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    flex: 1 1 auto;
+    min-height: 0;
+    max-height: none;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.league-filter-item {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    font-size: 14px;
+    cursor: pointer;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    background: rgba(255, 255, 255, 0.03);
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    position: relative;
+}
+
+.league-filter-item:hover,
+.league-filter-item:focus-within {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.16);
+}
+
+.league-filter-item-active {
+    background: rgba(74, 158, 255, 0.1);
+    border-color: rgba(74, 158, 255, 0.35);
+}
+
+.league-filter-checkbox {
+    position: absolute;
+    left: 12px;
+    opacity: 0;
+    width: 20px;
+    height: 20px;
+    margin: 0;
+    cursor: pointer;
+    z-index: 1;
+}
+
+.league-filter-check {
+    width: 20px;
+    height: 20px;
+    border-radius: 6px;
+    border: 2px solid rgba(255, 255, 255, 0.28);
+    background: rgba(0, 0, 0, 0.2);
+    flex-shrink: 0;
+    position: relative;
+}
+
+.league-filter-item-active .league-filter-check {
+    border-color: var(--primary-blue);
+    background: var(--primary-blue);
+}
+
+.league-filter-item-active .league-filter-check::after {
+    content: '';
+    position: absolute;
+    left: 5px;
+    top: 1px;
+    width: 6px;
+    height: 11px;
+    border: solid white;
+    border-width: 0 2px 2px 0;
+    transform: rotate(45deg);
+}
+
+.league-filter-name {
+    flex: 1;
+    min-width: 0;
+    line-height: 1.35;
+}
+
+.league-filter-item:focus-within {
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.4);
+    border-color: rgba(74, 158, 255, 0.55);
+}
+
+.flyout-menu-section-actions {
+    margin-top: auto;
+    padding-bottom: max(18px, env(safe-area-inset-bottom, 0px));
+}
+
+.menu-action-button {
+    width: 100%;
+    background: rgba(255, 255, 255, 0.04);
+    color: var(--text-primary);
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 10px;
+    padding: 12px 14px;
+    font-size: 15px;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.menu-action-button-danger {
+    color: #ffb4b4;
+    border-color: rgba(255, 82, 82, 0.35);
+    background: rgba(255, 82, 82, 0.08);
+}
+
+.menu-action-button:hover,
+.menu-action-button:focus-visible {
+    background: rgba(255, 255, 255, 0.1);
+    border-color: rgba(255, 255, 255, 0.28);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.35);
+}
+
+.menu-action-button-danger:hover,
+.menu-action-button-danger:focus-visible {
+    background: rgba(255, 82, 82, 0.16);
+    border-color: rgba(255, 82, 82, 0.55);
+    box-shadow: 0 0 0 3px rgba(255, 82, 82, 0.3);
+}
+
 @media (max-width: 600px) {
     .page-header-inner {
         padding: 12px 16px;
@@ -481,11 +852,10 @@ button {
     }
 
     .platform-windows .page-header-inner {
-        padding-right: 120px;
+        padding-right: 64px;
     }
 
-    .header-build-info {
-        left: 16px;
-        display: none;
+    .header-left {
+        left: 12px;
     }
 }

--- a/VardyParty/wwwroot/css/app.css
+++ b/VardyParty/wwwroot/css/app.css
@@ -143,6 +143,11 @@ button {
     padding-top: max(32px, env(safe-area-inset-top, 0px));
 }
 
+/* Android TV has no phone status bar — don't reserve the 32px inset above the title. */
+.platform-android-tv .page-header {
+    padding-top: 0;
+}
+
 .header-brand {
     position: absolute;
     left: 50%;
@@ -305,6 +310,13 @@ button {
     width: 100%;
     margin: calc(50vh - 120px) auto 24px auto; /* vertically centered-ish */
     justify-content: center;
+}
+
+/* TV: keep device QR on-screen — no vertical centering that pushes content below the fold. */
+.platform-android-tv .auth-hero,
+.platform-android-tv .auth-hero.auth-hero-device {
+    margin: 8px auto 12px auto;
+    max-width: min(720px, calc(100vw - 48px));
 }
 
 .auth-message {
@@ -731,20 +743,28 @@ button {
     display: flex;
     align-items: center;
     gap: 10px;
+    width: 100%;
     padding: 10px 12px;
     font-size: 14px;
+    font-family: inherit;
+    text-align: left;
+    color: inherit;
     cursor: pointer;
     border-radius: 10px;
     border: 1px solid rgba(255, 255, 255, 0.08);
     background: rgba(255, 255, 255, 0.03);
     transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
     position: relative;
+    box-sizing: border-box;
 }
 
 .league-filter-item:hover,
+.league-filter-item:focus,
+.league-filter-item:focus-visible,
 .league-filter-item:focus-within {
     background: rgba(255, 255, 255, 0.06);
     border-color: rgba(255, 255, 255, 0.16);
+    outline: none;
 }
 
 .league-filter-item-active {
@@ -753,14 +773,7 @@ button {
 }
 
 .league-filter-checkbox {
-    position: absolute;
-    left: 12px;
-    opacity: 0;
-    width: 20px;
-    height: 20px;
-    margin: 0;
-    cursor: pointer;
-    z-index: 1;
+    display: none;
 }
 
 .league-filter-check {
@@ -796,10 +809,20 @@ button {
     line-height: 1.35;
 }
 
+.league-filter-item:focus,
+.league-filter-item:focus-visible,
 .league-filter-item:focus-within {
     outline: none;
     box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.4);
     border-color: rgba(74, 158, 255, 0.55);
+}
+
+.menu-chip-button:focus,
+.menu-chip-button:focus-visible {
+    background: rgba(74, 158, 255, 0.24);
+    border-color: rgba(74, 158, 255, 0.6);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(74, 158, 255, 0.35);
 }
 
 .flyout-menu-section-actions {

--- a/Version.props
+++ b/Version.props
@@ -9,10 +9,10 @@
   -->
   <PropertyGroup>
     <!-- Internal build counter - auto-incremented on every GitHub Actions build -->
-    <ApplicationVersion>147</ApplicationVersion>
+    <ApplicationVersion>148</ApplicationVersion>
     
     <!-- User-facing semantic version - bumped minor on main branch merges -->
-    <ApplicationDisplayVersion>1.7.114</ApplicationDisplayVersion>
+    <ApplicationDisplayVersion>1.7.115</ApplicationDisplayVersion>
     
     <!-- Product name for versioning -->
     <Product>VardyParty</Product>

--- a/Version.props
+++ b/Version.props
@@ -9,10 +9,10 @@
   -->
   <PropertyGroup>
     <!-- Internal build counter - auto-incremented on every GitHub Actions build -->
-    <ApplicationVersion>146</ApplicationVersion>
+    <ApplicationVersion>147</ApplicationVersion>
     
     <!-- User-facing semantic version - bumped minor on main branch merges -->
-    <ApplicationDisplayVersion>1.7.113</ApplicationDisplayVersion>
+    <ApplicationDisplayVersion>1.7.114</ApplicationDisplayVersion>
     
     <!-- Product name for versioning -->
     <Product>VardyParty</Product>

--- a/Version.props
+++ b/Version.props
@@ -9,10 +9,10 @@
   -->
   <PropertyGroup>
     <!-- Internal build counter - auto-incremented on every GitHub Actions build -->
-    <ApplicationVersion>148</ApplicationVersion>
+    <ApplicationVersion>149</ApplicationVersion>
     
     <!-- User-facing semantic version - bumped minor on main branch merges -->
-    <ApplicationDisplayVersion>1.7.115</ApplicationDisplayVersion>
+    <ApplicationDisplayVersion>1.7.116</ApplicationDisplayVersion>
     
     <!-- Product name for versioning -->
     <Product>VardyParty</Product>

--- a/scripts/run-windows-debug.ps1
+++ b/scripts/run-windows-debug.ps1
@@ -7,6 +7,9 @@
 #   pwsh ./scripts/run-windows-debug.ps1
 #   pwsh ./scripts/run-windows-debug.ps1 -Rebuild
 #   pwsh ./scripts/run-windows-debug.ps1 -NoLaunch
+#
+# CS2012 / DLL locked (VBCSCompiler, Xaml.Markup.Compiler, stale VardyParty.exe):
+#   Get-Process VardyParty,VBCSCompiler -EA SilentlyContinue | Stop-Process -Force; Get-CimInstance Win32_Process -Filter "Name LIKE '%Markup.Compiler%'" | ForEach-Object { Stop-Process -Id $_.ProcessId -Force -EA SilentlyContinue }
 
 param(
     [ValidateSet('Debug', 'Release')]
@@ -108,6 +111,58 @@ function Sync-AppXLayoutFromBuildOutput {
     if (Test-Path $wwwroot) {
         Copy-Item -Path (Join-Path $wwwroot '*') -Destination (Join-Path $appX 'wwwroot') -Recurse -Force
     }
+
+    # Loose-register install location is OutputRoot (win-x64), not AppX. Blazor static assets live in AppX\wwwroot\_framework after MSIX layout.
+    $appxFramework = Join-Path $appX 'wwwroot\_framework'
+    $outputFramework = Join-Path $wwwroot '_framework'
+    if (Test-Path $appxFramework) {
+        Write-Host "Mirroring AppX Blazor _framework into output wwwroot for loose-register"
+        New-Item -ItemType Directory -Path $outputFramework -Force | Out-Null
+        Copy-Item -Path (Join-Path $appxFramework '*') -Destination $outputFramework -Recurse -Force
+    }
+
+    foreach ($leaf in @('index.html', 'VardyParty.styles.css')) {
+        $appxFile = Join-Path $appX "wwwroot\$leaf"
+        $outputFile = Join-Path $wwwroot $leaf
+        if (Test-Path $appxFile) {
+            New-Item -ItemType Directory -Path (Split-Path $outputFile) -Force | Out-Null
+            Copy-Item -Path $appxFile -Destination $outputFile -Force
+        }
+    }
+
+    # Loose-register uses win-x64\AppxManifest.xml; splash/tile PNGs live under AppX after MSIX layout.
+    $msixAssetBases = @(
+        'vardyparty_splash_generatedSplashScreen',
+        'vardyparty_splashStoreLogo',
+        'vardyparty_splashMediumTile',
+        'vardyparty_splashLogo',
+        'vardyparty_splashSmallTile',
+        'vardyparty_splashWideTile',
+        'vardyparty_splashLargeTile'
+    )
+    foreach ($base in $msixAssetBases) {
+        $scaled = Join-Path $appX "$base.scale-100.png"
+        if (-not (Test-Path $scaled)) { continue }
+        Copy-Item -Path $scaled -Destination (Join-Path $appX "$base.png") -Force
+    }
+    Get-ChildItem -Path $appX -File -Filter '*.png' | ForEach-Object {
+        Copy-Item -Path $_.FullName -Destination (Join-Path $OutputRoot $_.Name) -Force
+    }
+    $appxPri = Join-Path $appX 'resources.pri'
+    if (Test-Path $appxPri) {
+        Copy-Item -Path $appxPri -Destination (Join-Path $OutputRoot 'resources.pri') -Force
+    }
+}
+
+function Test-BlazorWebViewAssets {
+    param([string]$OutputRoot)
+
+    $blazorJs = Join-Path $OutputRoot 'wwwroot\_framework\blazor.webview.js'
+    if (-not (Test-Path $blazorJs)) {
+        throw "Missing $blazorJs. Rebuild with -Rebuild so MSIX layout generates _framework, then re-run this script."
+    }
+
+    Write-Host "Blazor WebView asset OK: $blazorJs"
 }
 
 function Test-AppXWwwrootFresh {
@@ -156,6 +211,7 @@ $projectRoot = Join-Path $repoRoot 'VardyParty'
 Sync-AppXLayoutFromBuildOutput -OutputRoot $winOut -ProjectRoot $projectRoot -BuildConfiguration $Configuration
 Test-AppXBinaryFresh -OutputRoot $winOut
 Test-AppXWwwrootFresh -OutputRoot $winOut -ProjectRoot $projectRoot
+Test-BlazorWebViewAssets -OutputRoot $winOut
 
 $leagueDir = Join-Path $layoutDir 'wwwroot\images\leagues'
 if (-not (Test-Path (Join-Path $leagueDir 'lebanese-premier-league.png'))) {

--- a/tests/VardyParty.Core.Tests/BbcJsonParserTests.cs
+++ b/tests/VardyParty.Core.Tests/BbcJsonParserTests.cs
@@ -23,6 +23,27 @@ namespace VardyParty.Core.Tests
         }
 
         [Fact]
+        public void BuildEventStatusMapStreaming_ParsesEscapedInitialData_LikeBbc()
+        {
+            // BBC serves __INITIAL_DATA__ as an escaped JSON string assignment.
+            // Literal page text resembles: __INITIAL_DATA__="{\"id\":\"s-...\",\"status\":\"MidEvent\",...}"
+            var html =
+                "__INITIAL_DATA__=\"{" +
+                "\\\"id\\\":\\\"s-escaped1\\\"," +
+                "\\\"periodLabel\\\":{\\\"value\\\":\\\"87'\\\"}," +
+                "\\\"status\\\":\\\"MidEvent\\\"," +
+                "\\\"statusComment\\\":{\\\"value\\\":\\\"87 minutes\\\"}" +
+                "}\"";
+
+            var map = _parser.BuildEventStatusMapStreaming(html);
+
+            Assert.True(map.ContainsKey("s-escaped1"));
+            Assert.Equal("MidEvent", map["s-escaped1"].status);
+            Assert.Equal("87'", map["s-escaped1"].periodLabel);
+            Assert.Equal("87 minutes", map["s-escaped1"].statusComment);
+        }
+
+        [Fact]
         public void BuildEventStatusMapStreaming_MalformedJson_DoesNotThrow()
         {
             var malformed = "<script>window.__INITIAL_DATA__ = {\"events\":[{\"id\":\"s-1\",\"status\":\"Live\"}]"; // missing closing braces

--- a/tests/VardyParty.Core.Tests/HomePagePresentationServiceTests.cs
+++ b/tests/VardyParty.Core.Tests/HomePagePresentationServiceTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using VardyParty.Models;
@@ -27,11 +28,31 @@ namespace VardyParty.Core.Tests
             public void Dispose() => _subject.Dispose();
         }
 
+        private class PassthroughLeagueFilter : ILeagueFilterService
+        {
+            public IReadOnlySet<string> DefaultHiddenLeagues => LeagueFilterDefaults.HiddenLeagues;
+            public IReadOnlySet<string> HiddenLeagues => new HashSet<string>();
+            public event Action? Changed;
+
+            public bool IsLeagueVisible(string? league) => true;
+
+            public List<Game> FilterGames(IEnumerable<Game>? games) => games?.ToList() ?? new List<Game>();
+
+            public IReadOnlyList<string> GetKnownLeagues(IDictionary<string, List<Game>>? gamesByLeague) =>
+                gamesByLeague?.Keys.OrderBy(k => k).ToList() ?? new List<string>();
+
+            public void SetLeagueVisible(string league, bool visible) { }
+
+            public void SetLeaguesVisible(IEnumerable<string> leagues, bool visible) { }
+
+            public void ResetToDefaults() { }
+        }
+
         [Fact]
         public void SubscribesAndPublishesDisplayGroups()
         {
             var stub = new StubEnriched();
-            var svc = new HomePagePresentationService(stub);
+            var svc = new HomePagePresentationService(stub, new PassthroughLeagueFilter());
 
             List<Game>? received = null;
             var sub = svc.DisplayStream.Subscribe(list => received = list);
@@ -44,6 +65,34 @@ namespace VardyParty.Core.Tests
 
             Assert.NotNull(received);
             Assert.Single(received);
+
+            sub.Dispose();
+            svc.Dispose();
+            stub.Dispose();
+        }
+
+        [Fact]
+        public void RepublishesWhenLeagueFilterChanges()
+        {
+            var stub = new StubEnriched();
+            var filter = new LeagueFilterService(new InMemoryLeagueFilterPreferencesStore());
+            var svc = new HomePagePresentationService(stub, filter);
+
+            var received = new List<List<Game>>();
+            var sub = svc.DisplayStream.Subscribe(list => received.Add(list));
+
+            var now = DateTime.UtcNow;
+            var dict = new Dictionary<string, List<Game>>
+            {
+                ["Premier League"] = new List<Game> { new() { League = "Premier League", Home = "A", Away = "B", Start = now.AddMinutes(-10), IsFinished = false } },
+                ["NBA"] = new List<Game> { new() { League = "NBA", Home = "C", Away = "D", Start = now.AddMinutes(-10), IsFinished = false } }
+            };
+
+            stub.Push(dict);
+            Assert.Single(received.Last());
+
+            filter.SetLeagueVisible("NBA", true);
+            Assert.Equal(2, received.Last().Count);
 
             sub.Dispose();
             svc.Dispose();

--- a/tests/VardyParty.Core.Tests/LeagueFilterServiceTests.cs
+++ b/tests/VardyParty.Core.Tests/LeagueFilterServiceTests.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using VardyParty.Models;
+using VardyParty.Services;
+using Xunit;
+
+namespace VardyParty.Core.Tests;
+
+public class LeagueFilterServiceTests
+{
+  private static LeagueFilterService CreateService(InMemoryLeagueFilterPreferencesStore? store = null)
+    {
+        return new LeagueFilterService(store ?? new InMemoryLeagueFilterPreferencesStore());
+    }
+
+    [Fact]
+    public void DefaultHiddenLeagues_AreApplied_WhenNoSavedPreferences()
+    {
+        var svc = CreateService();
+
+        Assert.False(svc.IsLeagueVisible("NBA"));
+        Assert.True(svc.IsLeagueVisible("Premier League"));
+    }
+
+    [Fact]
+    public void FilterGames_ExcludesHiddenLeagues()
+    {
+        var svc = CreateService();
+        var games = new List<Game>
+        {
+            new() { League = "Premier League", Home = "A", Away = "B" },
+            new() { League = "NBA", Home = "C", Away = "D" }
+        };
+
+        var filtered = svc.FilterGames(games);
+
+        Assert.Single(filtered);
+        Assert.Equal("Premier League", filtered[0].League);
+    }
+
+    [Fact]
+    public void SetLeagueVisible_PersistsAndRaisesChanged()
+    {
+        var store = new InMemoryLeagueFilterPreferencesStore();
+        var svc = CreateService(store);
+        var changed = false;
+        svc.Changed += () => changed = true;
+
+        svc.SetLeagueVisible("NBA", true);
+
+        Assert.True(svc.IsLeagueVisible("NBA"));
+        Assert.True(store.HasSavedPreferences);
+        Assert.True(changed);
+    }
+
+    [Fact]
+    public void SetLeaguesVisible_UpdatesMultipleLeaguesOnce()
+    {
+        var store = new InMemoryLeagueFilterPreferencesStore();
+        var svc = CreateService(store);
+        var changeCount = 0;
+        svc.Changed += () => changeCount++;
+
+        svc.SetLeaguesVisible(new[] { "NBA", "NHL" }, true);
+
+        Assert.True(svc.IsLeagueVisible("NBA"));
+        Assert.True(svc.IsLeagueVisible("NHL"));
+        Assert.Equal(1, changeCount);
+    }
+
+    [Fact]
+    public void ResetToDefaults_RestoresDefaultHiddenSet()
+    {
+        var store = new InMemoryLeagueFilterPreferencesStore();
+        var svc = CreateService(store);
+
+        svc.SetLeagueVisible("NBA", true);
+        svc.ResetToDefaults();
+
+        Assert.False(svc.IsLeagueVisible("NBA"));
+        Assert.False(store.HasSavedPreferences);
+    }
+
+    [Fact]
+    public void GetKnownLeagues_ReturnsSortedLeagueNames()
+    {
+        var svc = CreateService();
+        var dict = new Dictionary<string, List<Game>>
+        {
+            ["Serie A"] = new(),
+            ["Bundesliga"] = new(),
+            ["Premier League"] = new()
+        };
+
+        var leagues = svc.GetKnownLeagues(dict);
+
+        Assert.Equal(new[] { "Bundesliga", "Premier League", "Serie A" }, leagues);
+    }
+}

--- a/tests/VardyParty.Core.Tests/RefererHandlingTests.cs
+++ b/tests/VardyParty.Core.Tests/RefererHandlingTests.cs
@@ -41,7 +41,7 @@ public class RefererHandlingTests
         var healthChecker = new CapturingHealthChecker();
         var localLanPlayService = new Mock<ILocalLanPlayService>();
         localLanPlayService
-            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<CancellationToken>()))
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new M3U8Response { Url = "https://cdn.test/playlist.m3u8" });
 
         var resolver =

--- a/tests/VardyParty.Core.Tests/RefererHandlingTests.cs
+++ b/tests/VardyParty.Core.Tests/RefererHandlingTests.cs
@@ -32,7 +32,14 @@ public class RefererHandlingTests
         var handler = new FakeHttpHandler();
         var playUrl = $"https://api.test/play/{Uri.EscapeDataString(stream.Url)}";
         // ReSharper disable once InconsistentNaming
-        var m3u8Resp = new M3U8Response { Url = "https://cdn.test/playlist.m3u8" };
+        var m3u8Resp = new M3U8Response
+        {
+            Url = "https://cdn.test/playlist.m3u8",
+            RequestHeaders = new Dictionary<string, string>
+            {
+                ["referer"] = "https://player.example/player.html"
+            }
+        };
         handler.AddResponse(playUrl, new HttpResponseMessage(HttpStatusCode.OK)
         {
             Content = new StringContent(JsonSerializer.Serialize(m3u8Resp), Encoding.UTF8, "application/json")
@@ -42,7 +49,7 @@ public class RefererHandlingTests
         var localLanPlayService = new Mock<ILocalLanPlayService>();
         localLanPlayService
             .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new M3U8Response { Url = "https://cdn.test/playlist.m3u8" });
+            .ReturnsAsync(m3u8Resp);
 
         var resolver =
             new StreamResolver(healthChecker, localLanPlayService.Object, NullLogger<StreamResolver>.Instance);
@@ -56,8 +63,9 @@ public class RefererHandlingTests
 
         // Assert
         Assert.Single(list);
-        Assert.Equal(stream.Url, healthChecker.CapturedReferer);
+        Assert.Equal("https://player.example/player.html", healthChecker.CapturedReferer);
         Assert.Equal("https://cdn.test/playlist.m3u8", healthChecker.CapturedM3U8);
+        Assert.Equal("https://player.example/player.html", list[0].Referer);
     }
 
     [Fact]

--- a/tests/VardyParty.Core.Tests/StreamCatalogSourceOrdererTests.cs
+++ b/tests/VardyParty.Core.Tests/StreamCatalogSourceOrdererTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Linq;
+using VardyParty.Models;
+using VardyParty.Resolvers;
+using Xunit;
+
+namespace VardyParty.Core.Tests;
+
+public class StreamCatalogSourceOrdererTests
+{
+    [Fact]
+    public void OrderFbBeforeMp_PlacesFbStreamsAheadOfMp()
+    {
+        var streams = new List<Stream>
+        {
+            new() { Url = "https://mpoutqn.example/watch/1", Channel = "MP HD", Source = "mp", ResolutionStrategy = "v2" },
+            new() { Url = "https://footybitex.example/watch/1", Channel = "FB HD", Source = "fb" },
+            new() { Url = "https://mpoutqn.example/watch/2", Channel = "MP SD", Source = "mp", ResolutionStrategy = "v2" },
+            new() { Url = "https://footybitex.example/watch/2", Channel = "FB SD", Source = "fb" }
+        };
+
+        var ordered = StreamCatalogSourceOrderer.OrderFbBeforeMp(streams);
+
+        Assert.Equal(["FB HD", "FB SD", "MP HD", "MP SD"], ordered.Select(s => s.Channel).ToList());
+    }
+
+    [Fact]
+    public void OrderFbBeforeMp_PreservesRelativeOrderWithinSource()
+    {
+        var streams = new List<Stream>
+        {
+            new() { Url = "https://footybitex.example/a", Channel = "FB A", Source = "fb" },
+            new() { Url = "https://mpoutqn.example/a", Channel = "MP A", Source = "mp", ResolutionStrategy = "v2" },
+            new() { Url = "https://footybitex.example/b", Channel = "FB B", Source = "fb" },
+            new() { Url = "https://mpoutqn.example/b", Channel = "MP B", Source = "mp", ResolutionStrategy = "v2" }
+        };
+
+        var ordered = StreamCatalogSourceOrderer.OrderFbBeforeMp(streams);
+
+        Assert.Equal(["FB A", "FB B", "MP A", "MP B"], ordered.Select(s => s.Channel).ToList());
+    }
+
+    [Fact]
+    public void OrderIndexesFbBeforeMp_PartitionsRecommendedOrderBySource()
+    {
+        var streams = new List<Stream>
+        {
+            new() { Url = "https://mpoutqn.example/1", Channel = "MP 1", Source = "mp", ResolutionStrategy = "v2" },
+            new() { Url = "https://footybitex.example/1", Channel = "FB 1", Source = "fb" },
+            new() { Url = "https://mpoutqn.example/2", Channel = "MP 2", Source = "mp", ResolutionStrategy = "v2" }
+        };
+
+        var orderedIndexes = StreamCatalogSourceOrderer.OrderIndexesFbBeforeMp(
+            [0, 1, 2],
+            index => streams[index]);
+
+        Assert.Equal([1, 0, 2], orderedIndexes);
+    }
+}

--- a/tests/VardyParty.Core.Tests/StreamCatalogSourceTests.cs
+++ b/tests/VardyParty.Core.Tests/StreamCatalogSourceTests.cs
@@ -1,0 +1,47 @@
+using VardyParty.Models;
+using Xunit;
+
+namespace VardyParty.Core.Tests;
+
+public class StreamCatalogSourceTests
+{
+    [Fact]
+    public void ResolveCatalogSource_TagsFootybitexUrlAsFbEvenWhenSourceSaysMp()
+    {
+        var stream = new Stream
+        {
+            Url = "https://www.footybitex.com/game/Argentina-vs-Cape-Verde/71210",
+            Source = "mp",
+            ResolutionStrategy = "v2"
+        };
+
+        Assert.Equal("fb", stream.ResolveCatalogSource());
+        Assert.Equal("FB", stream.CatalogSourceBadgeLabel);
+    }
+
+    [Fact]
+    public void ResolveCatalogSource_TagsMpoutqnUrlAsMp()
+    {
+        var stream = new Stream
+        {
+            Url = "https://jack09eo.mpoutqn4vebroad.my/football/fifa-world-cup-4374999/argentina-vs-cabo-verde.html",
+            Source = "fb"
+        };
+
+        Assert.Equal("mp", stream.ResolveCatalogSource());
+        Assert.Equal("V2", stream.CatalogSourceBadgeLabel);
+    }
+
+    [Fact]
+    public void ResolveCatalogSource_UsesV2StrategyOnlyWhenUrlIsMpHost()
+    {
+        var stream = new Stream
+        {
+            Url = "https://live.example/stream",
+            ResolutionStrategy = "v2",
+            Source = "mp"
+        };
+
+        Assert.Equal("fb", stream.ResolveCatalogSource());
+    }
+}

--- a/tests/VardyParty.Core.Tests/StreamDeduplicatorTests.cs
+++ b/tests/VardyParty.Core.Tests/StreamDeduplicatorTests.cs
@@ -164,6 +164,33 @@ namespace VardyParty.Core.Tests
         }
 
         [Fact]
+        public void DeduplicateStreams_V2SameUrlDifferentPlayerLabels_KeepsAll()
+        {
+            var dedup = CreateDeduplicator();
+            var streams = new List<Models.Stream>
+            {
+                new Models.Stream
+                {
+                    Url = "https://madplay.example/match",
+                    Channel = "Fola ID",
+                    PlayerStream = "Fola ID",
+                    ResolutionStrategy = "v2"
+                },
+                new Models.Stream
+                {
+                    Url = "https://madplay.example/match",
+                    Channel = "Fubo US",
+                    PlayerStream = "Fubo US",
+                    ResolutionStrategy = "v2"
+                }
+            };
+
+            var result = dedup.DeduplicateStreams(streams);
+
+            Assert.Equal(2, result.Count);
+        }
+
+        [Fact]
         public void DeduplicateStreams_CaseInsensitiveUrlMatching()
         {
             var dedup = CreateDeduplicator();

--- a/tests/VardyParty.Core.Tests/StreamHealthCheckerTests.cs
+++ b/tests/VardyParty.Core.Tests/StreamHealthCheckerTests.cs
@@ -182,6 +182,31 @@ public class StreamHealthCheckerTests
     }
 
     [Fact]
+    public async Task CheckStreamHealth_SegmentHeadForbidden_GetRangeSuccess()
+    {
+        var handler = new FakeHttpMessageHandler();
+        var client = new HttpClient(handler);
+        var settingsProvider = _fixture.Create<StreamHealthSettings>();
+        var checker = new StreamHealthChecker(client, NullLogger<StreamHealthChecker>.Instance,
+            Options.Create(settingsProvider));
+
+        var manifestUrl = "http://example.com/playlist.m3u8";
+        var segmentUrl = "http://example.com/segment.ts";
+
+        handler.AddResponse(manifestUrl, new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent($"#EXTM3U\n#EXTINF:10,\n{segmentUrl}")
+        });
+
+        handler.AddResponse($"HEAD:{segmentUrl}", new HttpResponseMessage(HttpStatusCode.Forbidden));
+        handler.AddResponse(segmentUrl, new HttpResponseMessage(HttpStatusCode.OK));
+
+        var result = await checker.CheckStreamHealthAsync(manifestUrl, "http://referer.com");
+
+        Assert.Equal(StreamHealthStatus.Healthy, result.Status);
+    }
+
+    [Fact]
     public async Task CheckStreamHealth_SegmentHeadFail_GetSuccess()
     {
         var handler = new FakeHttpMessageHandler();

--- a/tests/VardyParty.Core.Tests/StreamHealthIdentityTests.cs
+++ b/tests/VardyParty.Core.Tests/StreamHealthIdentityTests.cs
@@ -1,0 +1,92 @@
+using VardyParty.Health;
+using VardyParty.Models;
+using Xunit;
+
+namespace VardyParty.Core.Tests;
+
+public class StreamHealthIdentityTests
+{
+    [Fact]
+    public void GetStreamName_V1Stream_ReturnsNull()
+    {
+        var stream = new Stream
+        {
+            Url = "https://example.com/stream1",
+            Channel = "Server A"
+        };
+
+        Assert.Null(StreamHealthIdentity.GetStreamName(stream));
+    }
+
+    [Fact]
+    public void GetStreamName_V2Stream_ReturnsPlayerStreamLabel()
+    {
+        var stream = new Stream
+        {
+            Url = "https://example.com/match.html",
+            ResolutionStrategy = "v2",
+            PlayerStream = "TyR",
+            StreamStatus = "ready"
+        };
+
+        Assert.Equal("TyR", StreamHealthIdentity.GetStreamName(stream));
+    }
+
+    [Fact]
+    public void BuildStreamKey_V2_IncludesStreamName()
+    {
+        const string pageUrl = "https://example.com/match.html?x=1";
+
+        var key = StreamHealthIdentity.BuildStreamKey(pageUrl, "TyR");
+
+        Assert.Equal("https://example.com/match.html::TyR", key);
+    }
+
+    [Fact]
+    public void BuildStreamKey_V1_UsesUrlOnly()
+    {
+        const string url = "https://example.com/stream1";
+
+        var key = StreamHealthIdentity.BuildStreamKey(url, null);
+
+        Assert.Equal("https://example.com/stream1", key);
+    }
+
+    [Fact]
+    public void FromStream_V2_ReturnsUrlAndStreamName()
+    {
+        var stream = new Stream
+        {
+            Url = "https://example.com/match.html",
+            ResolutionStrategy = "v2",
+            PlayerStream = "Fola ID",
+            StreamStatus = "ready"
+        };
+
+        var (streamUrl, streamName) = StreamHealthIdentity.FromStream(stream);
+
+        Assert.Equal("https://example.com/match.html", streamUrl);
+        Assert.Equal("Fola ID", streamName);
+    }
+
+    [Fact]
+    public void MatchesRecommendation_RequiresLabel_WhenRecommendationIncludesStreamName()
+    {
+        var stream = new Stream
+        {
+            Url = "https://madplay.example/match",
+            Channel = "Fubo US",
+            PlayerStream = "Fubo US",
+            ResolutionStrategy = "v2"
+        };
+
+        Assert.True(StreamHealthIdentity.MatchesRecommendation(
+            stream,
+            "https://madplay.example/match",
+            "Fubo US"));
+        Assert.False(StreamHealthIdentity.MatchesRecommendation(
+            stream,
+            "https://madplay.example/match",
+            "TyR"));
+    }
+}

--- a/tests/VardyParty.Core.Tests/StreamResolverTests.cs
+++ b/tests/VardyParty.Core.Tests/StreamResolverTests.cs
@@ -124,11 +124,9 @@ public class StreamResolverTests
     }
 
     [Fact]
-    public async Task ResolveStreamsIncrementallyAsync_FailedHealthCheck_MarksFailed()
+    public async Task ResolveStreamsIncrementallyAsync_SegmentUnreachable_StillTrustsLocalServiceM3U8()
     {
-        // Arrange
         var stream = new Stream { Url = "http://stream.com/1", Channel = "Channel1" };
-        // ReSharper disable once InconsistentNaming
         const string m3u8Url = "http://m3u8.com/playlist.m3u8";
 
         _localLanPlayServiceMock
@@ -139,14 +137,36 @@ public class StreamResolverTests
             .Setup(h => h.CheckStreamHealthAsync(m3u8Url, It.IsAny<string>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new StreamHealth { Status = StreamHealthStatus.SegmentUnreachable });
 
-        // Act
         var results = new List<EnrichedStream>();
         await foreach (var enriched in Sut.ResolveStreamsIncrementallyAsync([stream]))
         {
             results.Add(enriched);
         }
 
-        // Assert
+        Assert.Single(results);
+        Assert.Equal(StreamResolutionStatus.Healthy, results[0].Status);
+    }
+
+    [Fact]
+    public async Task ResolveStreamsIncrementallyAsync_InvalidManifestHealthCheck_MarksFailed()
+    {
+        var stream = new Stream { Url = "http://stream.com/1", Channel = "Channel1" };
+        const string m3u8Url = "http://m3u8.com/playlist.m3u8";
+
+        _localLanPlayServiceMock
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new M3U8Response { Url = m3u8Url });
+
+        _healthCheckerMock
+            .Setup(h => h.CheckStreamHealthAsync(m3u8Url, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StreamHealth { Status = StreamHealthStatus.InvalidManifest });
+
+        var results = new List<EnrichedStream>();
+        await foreach (var enriched in Sut.ResolveStreamsIncrementallyAsync([stream]))
+        {
+            results.Add(enriched);
+        }
+
         Assert.Single(results);
         Assert.Equal(StreamResolutionStatus.Failed, results[0].Status);
     }
@@ -154,17 +174,14 @@ public class StreamResolverTests
     [Fact]
     public async Task ResolveM3U8UrlAsync_ResolutionFails_ReturnsNull()
     {
-        // Arrange
         var stream = new Stream { Url = "http://stream.com/1", Channel = "Channel1" };
 
         _localLanPlayServiceMock
             .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((M3U8Response?)null);
 
-        // Act
         var result = await Sut.ResolveM3U8UrlAsync(stream, "http://example.com");
 
-        // Assert: Returns null because no valid configuration/HTTP response
         Assert.Null(result);
     }
 
@@ -185,6 +202,89 @@ public class StreamResolverTests
 
         // Assert
         Assert.Equal(m3u8Url, result);
+    }
+
+    [Fact]
+    public async Task ResolveStreamsIncrementallyAsync_V2PlayerStream_PassesLabelToLocalService()
+    {
+        var stream = new Stream
+        {
+            Url = "https://madplay.example/match",
+            Channel = "Fubo US",
+            PlayerStream = "Fubo US",
+            ResolutionStrategy = "v2",
+            StreamStatus = "ready"
+        };
+        const string m3u8Url = "http://m3u8.com/playlist.m3u8";
+
+        _localLanPlayServiceMock
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, "Fubo US", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new M3U8Response { Url = m3u8Url });
+
+        _healthCheckerMock
+            .Setup(h => h.CheckStreamHealthAsync(m3u8Url, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StreamHealth { Status = StreamHealthStatus.Healthy });
+
+        var results = new List<EnrichedStream>();
+        await foreach (var enriched in Sut.ResolveStreamsIncrementallyAsync([stream]))
+        {
+            results.Add(enriched);
+        }
+
+        Assert.Single(results);
+        Assert.Equal(StreamResolutionStatus.Healthy, results[0].Status);
+        _localLanPlayServiceMock.Verify(
+            s => s.ResolveM3U8UrlAsync(stream.Url, "Fubo US", It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task ResolveStreamsIncrementallyAsync_HealthProbeUnreachable_StillTrustsLocalServiceM3U8()
+    {
+        var stream = new Stream { Url = "https://madplay.example/match", Channel = "TyR", PlayerStream = "TyR" };
+        const string m3u8Url = "http://m3u8.com/playlist.m3u8?token=abc";
+
+        _localLanPlayServiceMock
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new M3U8Response { Url = m3u8Url });
+
+        _healthCheckerMock
+            .Setup(h => h.CheckStreamHealthAsync(m3u8Url, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StreamHealth { Status = StreamHealthStatus.SegmentUnreachable, Url = m3u8Url });
+
+        var results = new List<EnrichedStream>();
+        await foreach (var enriched in Sut.ResolveStreamsIncrementallyAsync([stream]))
+        {
+            results.Add(enriched);
+        }
+
+        Assert.Single(results);
+        Assert.Equal(StreamResolutionStatus.Healthy, results[0].Status);
+        Assert.Equal(m3u8Url, results[0].ResolvedM3U8Url);
+    }
+
+    [Fact]
+    public async Task ResolveStreamsIncrementallyAsync_HealthProbeInvalidManifest_StillFails()
+    {
+        var stream = new Stream { Url = "https://madplay.example/match", Channel = "TyR" };
+        const string m3u8Url = "http://m3u8.com/playlist.m3u8";
+
+        _localLanPlayServiceMock
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new M3U8Response { Url = m3u8Url });
+
+        _healthCheckerMock
+            .Setup(h => h.CheckStreamHealthAsync(m3u8Url, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StreamHealth { Status = StreamHealthStatus.InvalidManifest, Url = m3u8Url });
+
+        var results = new List<EnrichedStream>();
+        await foreach (var enriched in Sut.ResolveStreamsIncrementallyAsync([stream]))
+        {
+            results.Add(enriched);
+        }
+
+        Assert.Single(results);
+        Assert.Equal(StreamResolutionStatus.Failed, results[0].Status);
     }
 
     [Fact]

--- a/tests/VardyParty.Core.Tests/StreamResolverTests.cs
+++ b/tests/VardyParty.Core.Tests/StreamResolverTests.cs
@@ -43,7 +43,7 @@ public class StreamResolverTests
         const string m3u8Url = "http://m3u8.com/playlist.m3u8?token=abc";
 
         _localLanPlayServiceMock
-            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<CancellationToken>()))
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new M3U8Response { Url = m3u8Url });
 
         _healthCheckerMock
@@ -81,7 +81,7 @@ public class StreamResolverTests
             .ToList();
 
         _localLanPlayServiceMock
-            .Setup(s => s.ResolveM3U8UrlAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Setup(s => s.ResolveM3U8UrlAsync(It.IsAny<string>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new M3U8Response { Url = "http://m3u8.com/playlist.m3u8" });
 
         _healthCheckerMock
@@ -107,7 +107,7 @@ public class StreamResolverTests
         var stream = new Stream { Url = "http://stream.com/1", Channel = "Channel1" };
 
         _localLanPlayServiceMock
-            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<CancellationToken>()))
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((M3U8Response?)null);
 
         // Act
@@ -132,7 +132,7 @@ public class StreamResolverTests
         const string m3u8Url = "http://m3u8.com/playlist.m3u8";
 
         _localLanPlayServiceMock
-            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<CancellationToken>()))
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new M3U8Response { Url = m3u8Url });
 
         _healthCheckerMock
@@ -158,7 +158,7 @@ public class StreamResolverTests
         var stream = new Stream { Url = "http://stream.com/1", Channel = "Channel1" };
 
         _localLanPlayServiceMock
-            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<CancellationToken>()))
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((M3U8Response?)null);
 
         // Act
@@ -177,7 +177,7 @@ public class StreamResolverTests
         const string m3u8Url = "http://m3u8.com/playlist.m3u8";
 
         _localLanPlayServiceMock
-            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<CancellationToken>()))
+            .Setup(s => s.ResolveM3U8UrlAsync(stream.Url, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new M3U8Response { Url = m3u8Url });
 
         // Act

--- a/tests/VardyParty.Core.Tests/V2StreamExpanderTests.cs
+++ b/tests/VardyParty.Core.Tests/V2StreamExpanderTests.cs
@@ -43,7 +43,7 @@ public class V2StreamExpanderTests
     }
 
     [Fact]
-    public void Expand_V2WithEmptyPlayerStreams_KeepsSingleEntry()
+    public void Expand_V2WithEmptyPlayerStreams_DropsEntry()
     {
         var stream = new Stream
         {
@@ -55,8 +55,24 @@ public class V2StreamExpanderTests
 
         var result = V2StreamExpander.Expand([stream]);
 
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public void Expand_MixedFbAndEmptyMp_OnlyKeepsFb()
+    {
+        var fb = new Stream { Url = "https://fb.example/a", Channel = "weakstreams", ResolutionStrategy = "direct" };
+        var mp = new Stream
+        {
+            Url = "https://madplay.example/match",
+            ResolutionStrategy = "v2",
+            PlayerStreams = []
+        };
+
+        var result = V2StreamExpander.Expand([fb, mp]);
+
         Assert.Single(result);
-        Assert.Same(stream, result[0]);
+        Assert.Same(fb, result[0]);
     }
 
     [Fact]

--- a/tests/VardyParty.Core.Tests/V2StreamExpanderTests.cs
+++ b/tests/VardyParty.Core.Tests/V2StreamExpanderTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using VardyParty.Models;
+using VardyParty.Resolvers;
+using Xunit;
+
+namespace VardyParty.Core.Tests;
+
+public class V2StreamExpanderTests
+{
+    [Fact]
+    public void Expand_NonV2Stream_ReturnsUnchanged()
+    {
+        var stream = new Stream { Url = "https://example.com/page", Channel = "HD" };
+
+        var result = V2StreamExpander.Expand([stream]);
+
+        Assert.Single(result);
+        Assert.Same(stream, result[0]);
+    }
+
+    [Fact]
+    public void Expand_V2WithPlayerStreams_CreatesOneCandidatePerLabel()
+    {
+        var stream = new Stream
+        {
+            Url = "https://madplay.example/match",
+            ResolutionStrategy = "v2",
+            StreamStatus = "ready",
+            PlayerStreams = ["Fola ID", "Fubo US", "Peacock"]
+        };
+
+        var result = V2StreamExpander.Expand([stream]);
+
+        Assert.Equal(3, result.Count);
+        Assert.All(result, s =>
+        {
+            Assert.Equal("v2", s.ResolutionStrategy);
+            Assert.Equal(stream.Url, s.Url);
+            Assert.False(string.IsNullOrWhiteSpace(s.PlayerStream));
+            Assert.Equal(s.PlayerStream, s.Channel);
+        });
+        Assert.Equal(["Fola ID", "Fubo US", "Peacock"], result.Select(s => s.PlayerStream).ToList());
+    }
+
+    [Fact]
+    public void Expand_V2WithEmptyPlayerStreams_KeepsSingleEntry()
+    {
+        var stream = new Stream
+        {
+            Url = "https://madplay.example/match",
+            Channel = "Fallback",
+            ResolutionStrategy = "v2",
+            PlayerStreams = []
+        };
+
+        var result = V2StreamExpander.Expand([stream]);
+
+        Assert.Single(result);
+        Assert.Same(stream, result[0]);
+    }
+
+    [Fact]
+    public void Expand_V2DuplicateLabels_DeduplicatesCaseInsensitively()
+    {
+        var stream = new Stream
+        {
+            Url = "https://madplay.example/match",
+            ResolutionStrategy = "v2",
+            PlayerStreams = ["Fubo US", "fubo us", "Peacock"]
+        };
+
+        var result = V2StreamExpander.Expand([stream]);
+
+        Assert.Equal(2, result.Count);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds client support for API v2 stream metadata (multi-label MP/MadPlay pages) and resolves those streams via LAN `VardyParty.LocalService`.
- Orders catalog candidates FB-first, with league filters and player/UI fixes needed for preview e2e.
- Keeps DEBUG API targeting via `VARDYPARTY_DEBUG_API` (local/preview/prod); release `appsettings` continue to point at production HeadlessBaseUrl.

## Test plan
- [x] `dotnet test` focused stream tests (StreamResolver / V2 / Catalog / Dedup / Health) — 52 passed
- [ ] Manual: LocalService running on LAN; play an MP/v2 stream and confirm `?stream=` label is used when service advertises `play.stream`
- [ ] Manual: FB streams still resolve without LocalService MadPlay path
- [ ] Confirm Auth0 audience stays production for Release builds

## Release notes / follow-ups
- M3U8-resolver LocalService (MadPlay / non-FB `/play`) is already on `main` at v1.0.6; Client NuGet on `main` is still `0.1.23` — bump to `0.2.1` once GitHub Packages publish succeeds (packaged locally, push blocked for this agent identity).
- Pair merge with API `preview` → `main` only when MP secrets / FB+MP scrape policy for production are approved (no agent production deploy).
